### PR TITLE
pollAll() fix for lazy dependencies

### DIFF
--- a/lib/copacetic.js
+++ b/lib/copacetic.js
@@ -110,12 +110,7 @@ module.exports = (Dependency) => {
      * @return {Copacetic}
      */
     pollAll ({ interval, parallel, schedule } = {}) {
-      const dependencies = this.dependencyNames.map(s => ({
-        name: this.getDependency(s).name,
-        retries: 1
-      }))
-
-      this.poll({ dependencies, interval, parallel, schedule })
+      this.poll({ dependencies: 'all', interval, parallel, schedule })
 
       return this
     }
@@ -160,10 +155,21 @@ module.exports = (Dependency) => {
       const start = process.hrtime()
       const _check = name
         ? () => this._checkOne(name, 1, humanInterval(maxDelay))
-        : () => this._checkMany(dependencies, parallel)
+        : (_dependencies) => this._checkMany(_dependencies, parallel)
 
       const loop = () => {
-        _check()
+        let _dependencies = []
+
+        if (dependencies === 'all') {
+          _dependencies = this.dependencyNames.map(s => ({
+            name: this.getDependency(s).name,
+            retries: 1
+          }))
+        } else {
+          _dependencies = dependencies
+        }
+
+        _check(_dependencies)
           .catch(e => e)
           .then((res) => {
             this.emit('health', res, this.stop.bind(this))


### PR DESCRIPTION
- Fixed dependencies not being checked after pollAll was called. It's far from beautiful, but it works.

