### PR TITLE
Adding cluster-messages to dependencies and out of optionalPeerDependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,323 +1,410 @@
 {
   "name": "@fresh8/copacetic",
   "version": "3.6.1",
+  "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@types/geojson": {
       "version": "1.0.2",
-      "from": "@types/geojson@https://registry.npmjs.org/@types/geojson/-/geojson-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.2.tgz",
+      "integrity": "sha1-sC0QqwKOKSisWSoFGqpJgaGUHQM=",
       "dev": true
     },
     "@types/node": {
       "version": "6.0.79",
-      "from": "@types/node@https://registry.npmjs.org/@types/node/-/node-6.0.79.tgz",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.79.tgz",
+      "integrity": "sha1-Xv59Sm2MRTx+nq9V2TH0oi+sUWk=",
       "dev": true
     },
     "acorn": {
       "version": "5.3.0",
-      "from": "acorn@https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
       "dev": true
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "from": "acorn-jsx@https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "^3.0.4"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "from": "acorn@https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
       }
     },
     "ajv": {
       "version": "4.11.8",
-      "from": "ajv@https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "dev": true
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "dev": true,
+      "requires": {
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
-      "from": "ajv-keywords@https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
     },
     "align-text": {
       "version": "0.1.4",
-      "from": "align-text@https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "dev": true
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
-      "from": "amdefine@https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
     "ansi-escape-sequences": {
       "version": "4.0.0",
-      "from": "ansi-escape-sequences@https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-4OywQpWLceQpQtNcH88dmwCg9n4=",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0"
+      }
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "from": "ansi-escapes@https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "from": "ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "argparse": {
       "version": "1.0.9",
-      "from": "argparse@https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "dev": true
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "argv-tools": {
       "version": "0.1.1",
-      "from": "argv-tools@https://registry.npmjs.org/argv-tools/-/argv-tools-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/argv-tools/-/argv-tools-0.1.1.tgz",
-      "dev": true
+      "integrity": "sha1-WIKD8zk62kcUFECxKYHNQb9rcDI=",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "find-replace": "^2.0.1"
+      }
     },
     "array-back": {
       "version": "2.0.0",
-      "from": "array-back@https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-aHdHHVHsycm/phNvtsfV/ml0gCI=",
+      "dev": true,
+      "requires": {
+        "typical": "^2.6.1"
+      }
     },
     "array-union": {
       "version": "1.0.2",
-      "from": "array-union@https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "dev": true
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
-      "from": "array-uniq@https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array.prototype.find": {
       "version": "2.0.4",
-      "from": "array.prototype.find@https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
       "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
-      "dev": true
+      "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
+      }
     },
     "arrify": {
       "version": "1.0.1",
-      "from": "arrify@https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asn1": {
       "version": "0.2.3",
-      "from": "asn1@https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
       "dev": true
     },
     "assert-plus": {
       "version": "0.2.0",
-      "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
       "dev": true
     },
     "assertion-error": {
       "version": "1.0.2",
-      "from": "assertion-error@https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
     },
     "async": {
       "version": "2.1.4",
-      "from": "async@https://registry.npmjs.org/async/-/async-2.1.4.tgz",
       "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
-      "dev": true
+      "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.14.0"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
-      "from": "asynckit@https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "aws-sign2": {
       "version": "0.6.0",
-      "from": "aws-sign2@https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
       "dev": true
     },
     "aws4": {
       "version": "1.6.0",
-      "from": "aws4@https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "from": "babel-code-frame@https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "dev": true
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
     },
     "babylon": {
       "version": "7.0.0-beta.19",
-      "from": "babylon@https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
+      "integrity": "sha1-6SjH6AfpcOBTaweKs+DEj54FJQM=",
       "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
-      "from": "balanced-match@https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
-      "from": "bcrypt-pbkdf@https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "bluebird": {
       "version": "3.5.0",
-      "from": "bluebird@https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
       "dev": true
     },
     "boom": {
       "version": "2.10.1",
-      "from": "boom@https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "dev": true
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.x.x"
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
-      "from": "brace-expansion@https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "dev": true
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "browser-stdout": {
       "version": "1.3.0",
-      "from": "browser-stdout@https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
     "bson": {
       "version": "1.0.4",
-      "from": "bson@https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
+      "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw=",
       "dev": true
     },
     "buffer-shims": {
       "version": "1.0.0",
-      "from": "buffer-shims@https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
       "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "from": "builtin-modules@https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "cache-point": {
       "version": "0.4.1",
-      "from": "cache-point@https://registry.npmjs.org/cache-point/-/cache-point-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-0.4.1.tgz",
-      "dev": true
+      "integrity": "sha1-zIycvZnZDXsMZpEM0z13oaq4hA4=",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "fs-then-native": "^2.0.0",
+        "mkdirp2": "^1.0.3"
+      }
     },
     "caller-path": {
       "version": "0.1.0",
-      "from": "caller-path@https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "dev": true
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      }
     },
     "callsites": {
       "version": "0.2.0",
-      "from": "callsites@https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
     "camelcase": {
       "version": "1.2.1",
-      "from": "camelcase@https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true,
       "optional": true
     },
     "caseless": {
       "version": "0.11.0",
-      "from": "caseless@https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
       "dev": true
     },
     "catharsis": {
       "version": "0.8.9",
-      "from": "catharsis@https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
-      "dev": true
+      "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+      "dev": true,
+      "requires": {
+        "underscore-contrib": "~0.3.0"
+      }
     },
     "center-align": {
       "version": "0.1.3",
-      "from": "center-align@https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
+      }
     },
     "chai": {
       "version": "3.5.0",
-      "from": "chai@https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "dev": true
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
+      }
     },
     "chalk": {
       "version": "1.1.3",
-      "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "dev": true
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
     },
     "circular-json": {
       "version": "0.3.3",
-      "from": "circular-json@https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli-cursor": {
       "version": "1.0.2",
-      "from": "cli-cursor@https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "dev": true
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^1.0.1"
+      }
     },
     "cli-width": {
       "version": "2.2.0",
-      "from": "cli-width@https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "cliui": {
       "version": "2.1.0",
-      "from": "cliui@https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
-          "from": "wordwrap@0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
           "dev": true,
           "optional": true
         }
@@ -325,1613 +412,2319 @@
     },
     "cls-bluebird": {
       "version": "2.0.1",
-      "from": "cls-bluebird@https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-wlmkgK4CwOUGE0MHuxPbMERu4uc=",
+      "dev": true,
+      "requires": {
+        "is-bluebird": "^1.0.2",
+        "shimmer": "^1.1.0"
+      }
     },
     "cluster-key-slot": {
       "version": "1.0.8",
-      "from": "cluster-key-slot@https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.0.8.tgz",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.0.8.tgz",
+      "integrity": "sha1-dlRVYIWmUzCTKi6LWXb44tCz5BQ=",
       "dev": true
     },
     "cluster-messages": {
       "version": "1.1.2",
-      "from": "cluster-messages@https://registry.npmjs.org/cluster-messages/-/cluster-messages-1.1.2.tgz",
-      "resolved": "https://registry.npmjs.org/cluster-messages/-/cluster-messages-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/cluster-messages/-/cluster-messages-1.1.2.tgz",
+      "integrity": "sha1-86dHQQoDOsjHWmnf/hF8lPPec1w=",
+      "requires": {
+        "uuid4": "^1.0.0"
+      }
     },
     "co": {
       "version": "4.6.0",
-      "from": "co@https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
-      "from": "code-point-at@https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "codependency": {
       "version": "2.0.1",
-      "from": "codependency@https://registry.npmjs.org/codependency/-/codependency-2.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/codependency/-/codependency-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/codependency/-/codependency-2.0.1.tgz",
+      "integrity": "sha1-0VOlSpYGKnX95IlYxNyV/z2z0JM=",
+      "requires": {
+        "semver": "^5.3.0"
+      }
     },
     "collect-all": {
       "version": "1.0.3",
-      "from": "collect-all@https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
-      "dev": true
+      "integrity": "sha1-GrzCBEi1ihRHSH/PNBMOlRKwrPg=",
+      "dev": true,
+      "requires": {
+        "stream-connect": "^1.0.2",
+        "stream-via": "^1.0.4"
+      }
     },
     "combined-stream": {
       "version": "1.0.5",
-      "from": "combined-stream@https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "dev": true
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "command-line-args": {
       "version": "5.0.1",
-      "from": "command-line-args@https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.1.tgz",
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-FhC6GjC1Zggc4/USaMGIjAWFh70=",
+      "dev": true,
+      "requires": {
+        "argv-tools": "^0.1.1",
+        "array-back": "^2.0.0",
+        "find-replace": "^2.0.1",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^2.6.1"
+      }
     },
     "command-line-tool": {
       "version": "0.8.0",
-      "from": "command-line-tool@https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz",
       "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz",
-      "dev": true
+      "integrity": "sha1-sAKQ7x38EcxzHdH0OpLPpfIecVs=",
+      "dev": true,
+      "requires": {
+        "ansi-escape-sequences": "^4.0.0",
+        "array-back": "^2.0.0",
+        "command-line-args": "^5.0.0",
+        "command-line-usage": "^4.1.0",
+        "typical": "^2.6.1"
+      }
     },
     "command-line-usage": {
       "version": "4.1.0",
-      "from": "command-line-usage@https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-      "dev": true
+      "integrity": "sha1-prOy4nA7Tc+L1GrhnhGKmlKXKII=",
+      "dev": true,
+      "requires": {
+        "ansi-escape-sequences": "^4.0.0",
+        "array-back": "^2.0.0",
+        "table-layout": "^0.4.2",
+        "typical": "^2.6.1"
+      }
     },
     "commander": {
       "version": "2.11.0",
-      "from": "commander@https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
       "dev": true
     },
     "common-sequence": {
       "version": "1.0.2",
-      "from": "common-sequence@https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
+      "integrity": "sha1-MOB/P49vf5s97oVPILLTnu4Ibeg=",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
-      "from": "concat-map@https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
       "version": "1.6.0",
-      "from": "concat-stream@https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "dev": true
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "config-master": {
       "version": "3.1.0",
-      "from": "config-master@https://registry.npmjs.org/config-master/-/config-master-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/config-master/-/config-master-3.1.0.tgz",
+      "integrity": "sha1-ZnZjWQUFooO/JqSE1oSJ10xUhdo=",
       "dev": true,
+      "requires": {
+        "walk-back": "^2.0.1"
+      },
       "dependencies": {
         "walk-back": {
           "version": "2.0.1",
-          "from": "walk-back@https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
+          "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
           "dev": true
         }
       }
     },
     "contains-path": {
       "version": "0.1.0",
-      "from": "contains-path@https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "from": "core-util-is@https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "coveralls": {
       "version": "2.13.1",
-      "from": "coveralls@https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
-      "dev": true
+      "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
+      }
     },
     "cross-env": {
       "version": "3.2.4",
-      "from": "cross-env@https://registry.npmjs.org/cross-env/-/cross-env-3.2.4.tgz",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-3.2.4.tgz",
-      "dev": true
+      "integrity": "sha1-ngWF8neGTtQhznVvgamA/w1piro=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^5.1.0",
+        "is-windows": "^1.0.0"
+      }
     },
     "cross-spawn": {
       "version": "5.1.0",
-      "from": "cross-spawn@https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "dev": true
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
     },
     "cryptiles": {
       "version": "2.0.5",
-      "from": "cryptiles@https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "dev": true
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
+      "requires": {
+        "boom": "2.x.x"
+      }
     },
     "d": {
       "version": "1.0.0",
-      "from": "d@https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.9"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
-      "from": "dashdash@https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "debug": {
       "version": "2.6.8",
-      "from": "debug@https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "dev": true
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "debug-log": {
       "version": "1.0.1",
-      "from": "debug-log@https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
     "decamelize": {
       "version": "1.2.0",
-      "from": "decamelize@https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true,
       "optional": true
     },
     "deep-eql": {
       "version": "0.1.3",
-      "from": "deep-eql@https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
-          "from": "type-detect@https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
           "dev": true
         }
       }
     },
     "deep-equal": {
       "version": "1.0.1",
-      "from": "deep-equal@https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
     "deep-extend": {
       "version": "0.5.0",
-      "from": "deep-extend@https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.0.tgz",
+      "integrity": "sha1-bvSgmwX5iw41jW2T1Mo8rsZnKAM=",
       "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
-      "from": "deep-is@https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "define-properties": {
       "version": "1.1.2",
-      "from": "define-properties@https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "dev": true
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
+      }
     },
     "deglob": {
       "version": "2.1.0",
-      "from": "deglob@https://registry.npmjs.org/deglob/-/deglob-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.0.tgz",
-      "dev": true
+      "integrity": "sha1-TUSr4W7zLHebSXK9FBqAMlApoUo=",
+      "dev": true,
+      "requires": {
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^3.0.9",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1"
+      }
     },
     "del": {
       "version": "2.2.2",
-      "from": "del@https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "dev": true
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "from": "delayed-stream@https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "denque": {
       "version": "1.1.1",
-      "from": "denque@https://registry.npmjs.org/denque/-/denque-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.1.1.tgz",
+      "integrity": "sha1-ECKcK4juwb0V/4LF/eNW5762254=",
       "dev": true
     },
     "depd": {
       "version": "1.1.0",
-      "from": "depd@https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM=",
       "dev": true
     },
     "diff": {
       "version": "3.2.0",
-      "from": "diff@https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
     "dmd": {
       "version": "3.0.10",
-      "from": "dmd@https://registry.npmjs.org/dmd/-/dmd-3.0.10.tgz",
       "resolved": "https://registry.npmjs.org/dmd/-/dmd-3.0.10.tgz",
-      "dev": true
+      "integrity": "sha1-+nLhFQ4quh/+Nf4tXUt3FszoNEs=",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "cache-point": "^0.4.1",
+        "common-sequence": "^1.0.2",
+        "file-set": "^1.1.1",
+        "handlebars": "^4.0.11",
+        "marked": "^0.3.12",
+        "object-get": "^2.1.0",
+        "reduce-flatten": "^1.0.1",
+        "reduce-unique": "^1.0.0",
+        "reduce-without": "^1.0.1",
+        "test-value": "^3.0.0",
+        "walk-back": "^3.0.0"
+      }
     },
     "doctrine": {
       "version": "2.1.0",
-      "from": "doctrine@https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "dev": true
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "dottie": {
       "version": "2.0.0",
-      "from": "dottie@https://registry.npmjs.org/dottie/-/dottie-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.0.tgz",
+      "integrity": "sha1-2hkZgci41xPKARXViYzzl8Lw3dA=",
       "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",
-      "from": "ecc-jsbn@https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "~0.1.0"
+      }
     },
     "encoding": {
       "version": "0.1.12",
-      "from": "encoding@https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "env-cmd": {
       "version": "5.1.0",
-      "from": "env-cmd@https://registry.npmjs.org/env-cmd/-/env-cmd-5.1.0.tgz",
       "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-5.1.0.tgz",
-      "dev": true
+      "integrity": "sha1-AjbbOTw/AzAFIE/NCpLuQHI6nJ4=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^5.0.1"
+      }
     },
     "error-ex": {
       "version": "1.3.1",
-      "from": "error-ex@https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "dev": true
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "es-abstract": {
       "version": "1.10.0",
-      "from": "es-abstract@https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
-      "dev": true
+      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
+      }
     },
     "es-to-primitive": {
       "version": "1.1.1",
-      "from": "es-to-primitive@https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "dev": true
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
+      }
     },
     "es5-ext": {
       "version": "0.10.38",
-      "from": "es5-ext@https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
-      "dev": true
+      "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1"
+      }
     },
     "es6-iterator": {
       "version": "2.0.3",
-      "from": "es6-iterator@https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "dev": true
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "es6-map": {
       "version": "0.1.5",
-      "from": "es6-map@https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "dev": true
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
+      }
     },
     "es6-promise": {
       "version": "3.2.1",
-      "from": "es6-promise@https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+      "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q=",
       "dev": true
     },
     "es6-set": {
       "version": "0.1.5",
-      "from": "es6-set@https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "dev": true
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "~0.3.5"
+      }
     },
     "es6-symbol": {
       "version": "3.1.1",
-      "from": "es6-symbol@https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "dev": true
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "es6-weak-map": {
       "version": "2.0.2",
-      "from": "es6-weak-map@https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-      "dev": true
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "from": "escape-string-regexp@https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "escope": {
       "version": "3.6.0",
-      "from": "escope@https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "dev": true
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "requires": {
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
     },
     "eslint": {
       "version": "3.19.0",
-      "from": "eslint@https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "dev": true
+      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.16.0",
+        "chalk": "^1.1.3",
+        "concat-stream": "^1.5.2",
+        "debug": "^2.1.1",
+        "doctrine": "^2.0.0",
+        "escope": "^3.6.0",
+        "espree": "^3.4.0",
+        "esquery": "^1.0.0",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "glob": "^7.0.3",
+        "globals": "^9.14.0",
+        "ignore": "^3.2.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^0.12.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.5.1",
+        "json-stable-stringify": "^1.0.0",
+        "levn": "^0.3.0",
+        "lodash": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.1",
+        "pluralize": "^1.2.1",
+        "progress": "^1.1.8",
+        "require-uncached": "^1.0.2",
+        "shelljs": "^0.7.5",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^3.7.8",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0"
+      }
     },
     "eslint-config-standard": {
       "version": "10.2.1",
-      "from": "eslint-config-standard@https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
+      "integrity": "sha1-wGHk0GbzedwXzVYsZOgZtN1FRZE=",
       "dev": true
     },
     "eslint-config-standard-jsx": {
       "version": "4.0.2",
-      "from": "eslint-config-standard-jsx@https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz",
       "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz",
+      "integrity": "sha512-F8fRh2WFnTek7dZH9ZaE0PCBwdVGkwVWZmizla/DDNOmg7Tx6B/IlK5+oYpiX29jpu73LszeJj5i1axEZv6VMw==",
       "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.2.3",
-      "from": "eslint-import-resolver-node@https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
-      "dev": true
+      "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "object-assign": "^4.0.1",
+        "resolve": "^1.1.6"
+      }
     },
     "eslint-module-utils": {
       "version": "2.1.1",
-      "from": "eslint-module-utils@https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "dev": true
+      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "pkg-dir": "^1.0.0"
+      }
     },
     "eslint-plugin-import": {
       "version": "2.2.0",
-      "from": "eslint-plugin-import@https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
+      "integrity": "sha1-crowb60wXWfEgWNIpGmaQimsi04=",
       "dev": true,
+      "requires": {
+        "builtin-modules": "^1.1.1",
+        "contains-path": "^0.1.0",
+        "debug": "^2.2.0",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.2.0",
+        "eslint-module-utils": "^2.0.0",
+        "has": "^1.0.1",
+        "lodash.cond": "^4.3.0",
+        "minimatch": "^3.0.3",
+        "pkg-up": "^1.0.0"
+      },
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
-          "from": "doctrine@https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "dev": true
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
         }
       }
     },
     "eslint-plugin-node": {
       "version": "4.2.3",
-      "from": "eslint-plugin-node@https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz",
-      "dev": true
+      "integrity": "sha512-vIUQPuwbVYdz/CYnlTLsJrRy7iXHQjdEe5wz0XhhdTym3IInM/zZLlPf9nZ2mThsH0QcsieCOWs2vOeCy/22LQ==",
+      "dev": true,
+      "requires": {
+        "ignore": "^3.0.11",
+        "minimatch": "^3.0.2",
+        "object-assign": "^4.0.1",
+        "resolve": "^1.1.7",
+        "semver": "5.3.0"
+      }
     },
     "eslint-plugin-promise": {
       "version": "3.5.0",
-      "from": "eslint-plugin-promise@https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz",
+      "integrity": "sha1-ePu2/+BHIBYnVp6FpsU3OvKmj8o=",
       "dev": true
     },
     "eslint-plugin-react": {
       "version": "6.10.3",
-      "from": "eslint-plugin-react@https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
+      "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
       "dev": true,
+      "requires": {
+        "array.prototype.find": "^2.0.1",
+        "doctrine": "^1.2.2",
+        "has": "^1.0.1",
+        "jsx-ast-utils": "^1.3.4",
+        "object.assign": "^4.0.4"
+      },
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
-          "from": "doctrine@https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "dev": true
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
         }
       }
     },
     "eslint-plugin-standard": {
       "version": "3.0.1",
-      "from": "eslint-plugin-standard@https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
+      "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
       "dev": true
     },
     "espree": {
       "version": "3.5.2",
-      "from": "espree@https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-      "dev": true
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.2.1",
+        "acorn-jsx": "^3.0.0"
+      }
     },
     "esprima": {
       "version": "2.7.3",
-      "from": "esprima@https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
       "dev": true
     },
     "esquery": {
       "version": "1.0.0",
-      "from": "esquery@https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
     },
     "esrecurse": {
       "version": "4.2.0",
-      "from": "esrecurse@https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-      "dev": true
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0",
+        "object-assign": "^4.0.1"
+      }
     },
     "estraverse": {
       "version": "4.2.0",
-      "from": "estraverse@https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.2",
-      "from": "esutils@https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "event-emitter": {
       "version": "0.3.5",
-      "from": "event-emitter@https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "dev": true
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "exit-hook": {
       "version": "1.1.1",
-      "from": "exit-hook@https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "extend": {
       "version": "3.0.1",
-      "from": "extend@https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
     "extsprintf": {
       "version": "1.0.2",
-      "from": "extsprintf@https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "from": "fast-levenshtein@https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "figures": {
       "version": "1.7.0",
-      "from": "figures@https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "dev": true
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      }
     },
     "file-entry-cache": {
       "version": "2.0.0",
-      "from": "file-entry-cache@https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
     },
     "file-set": {
       "version": "1.1.1",
-      "from": "file-set@https://registry.npmjs.org/file-set/-/file-set-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/file-set/-/file-set-1.1.1.tgz",
+      "integrity": "sha1-0+xwwIDsjxjyBLod4QZ4DJBWkms=",
       "dev": true,
+      "requires": {
+        "array-back": "^1.0.3",
+        "glob": "^7.1.0"
+      },
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "from": "array-back@https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "dev": true
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
+          "requires": {
+            "typical": "^2.6.0"
+          }
         }
       }
     },
     "find-replace": {
       "version": "2.0.1",
-      "from": "find-replace@https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-bZaDp8og+PmqvqutB+TiWA9ShVA=",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "test-value": "^3.0.0"
+      }
     },
     "find-root": {
       "version": "1.1.0",
-      "from": "find-root@https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "dev": true
     },
     "find-up": {
       "version": "1.1.2",
-      "from": "find-up@https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "dev": true
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "flat-cache": {
       "version": "1.3.0",
-      "from": "flat-cache@https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "dev": true
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
+      }
     },
     "flexbuffer": {
       "version": "0.0.6",
-      "from": "flexbuffer@https://registry.npmjs.org/flexbuffer/-/flexbuffer-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/flexbuffer/-/flexbuffer-0.0.6.tgz",
+      "integrity": "sha1-A5/fI/iCPkQMOPMnfm/vEXQhWzA=",
       "dev": true
     },
     "foreach": {
       "version": "2.0.5",
-      "from": "foreach@https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
-      "from": "forever-agent@https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
       "version": "2.1.4",
-      "from": "form-data@https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "dev": true
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
+      }
     },
     "formatio": {
       "version": "1.2.0",
-      "from": "formatio@https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-      "dev": true
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.x"
+      }
     },
     "fs-then-native": {
       "version": "2.0.0",
-      "from": "fs-then-native@https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
+      "integrity": "sha1-GaEk2U2QwiyOBF8ujdbr6jbUjGc=",
       "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "from": "fs.realpath@https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
-      "from": "function-bind@https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "generate-function": {
       "version": "2.0.0",
-      "from": "generate-function@https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
       "dev": true
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "from": "generate-object-property@https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "dev": true
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.0"
+      }
     },
     "generic-pool": {
       "version": "3.1.7",
-      "from": "generic-pool@https://registry.npmjs.org/generic-pool/-/generic-pool-3.1.7.tgz",
       "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.1.7.tgz",
+      "integrity": "sha1-2sIrLHp6BOQXMvfY0tJaMDyI9mI=",
       "dev": true
     },
     "get-stdin": {
       "version": "5.0.1",
-      "from": "get-stdin@https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "from": "getpass@https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "glob": {
       "version": "7.1.1",
-      "from": "glob@https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "dev": true
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
     },
     "globals": {
       "version": "9.18.0",
-      "from": "globals@https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globby": {
       "version": "5.0.0",
-      "from": "globby@https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "from": "graceful-fs@https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
-      "from": "graceful-readlink@https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
     "growl": {
       "version": "1.9.2",
-      "from": "growl@https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
     "handlebars": {
       "version": "4.0.11",
-      "from": "handlebars@https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
+      "requires": {
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.4.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         }
       }
     },
     "har-validator": {
       "version": "2.0.6",
-      "from": "har-validator@https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "dev": true
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "commander": "^2.9.0",
+        "is-my-json-valid": "^2.12.4",
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "has": {
       "version": "1.0.1",
-      "from": "has@https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.0.2"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
-      "from": "has-ansi@https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
     },
     "has-flag": {
       "version": "1.0.0",
-      "from": "has-flag@https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
-      "from": "has-symbols@https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "hawk": {
       "version": "3.1.3",
-      "from": "hawk@https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "dev": true
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true,
+      "requires": {
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
+      }
     },
     "hoek": {
       "version": "2.16.3",
-      "from": "hoek@https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
     "hooks-fixed": {
       "version": "2.0.0",
-      "from": "hooks-fixed@https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.0.tgz",
+      "integrity": "sha1-oB2JTVKsf2WZu7H2PfycQR33DLo=",
       "dev": true
     },
     "http-signature": {
       "version": "1.1.1",
-      "from": "http-signature@https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "dev": true
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
     },
     "human-interval": {
       "version": "0.1.6",
-      "from": "human-interval@https://registry.npmjs.org/human-interval/-/human-interval-0.1.6.tgz",
-      "resolved": "https://registry.npmjs.org/human-interval/-/human-interval-0.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/human-interval/-/human-interval-0.1.6.tgz",
+      "integrity": "sha1-AFeXNFR2TDq8vrKu1hL8lkTmhIg="
     },
     "iconv-lite": {
       "version": "0.4.18",
-      "from": "iconv-lite@https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+      "integrity": "sha1-I9hlaxaq5nQqwpcy6o8DNqR4nPI="
     },
     "ignore": {
       "version": "3.3.7",
-      "from": "ignore@https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "from": "imurmurhash@https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "inflection": {
       "version": "1.10.0",
-      "from": "inflection@https://registry.npmjs.org/inflection/-/inflection-1.10.0.tgz",
       "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.10.0.tgz",
+      "integrity": "sha1-W//LEZetPoEFD44X4hZoCH7p6y8=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "from": "inflight@https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "dev": true
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "inherits": {
       "version": "2.0.3",
-      "from": "inherits@https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "inquirer": {
       "version": "0.12.0",
-      "from": "inquirer@https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "dev": true
+      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
+      }
     },
     "interpret": {
       "version": "1.1.0",
-      "from": "interpret@https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "ioredis": {
       "version": "3.1.1",
-      "from": "ioredis@https://registry.npmjs.org/ioredis/-/ioredis-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-3.1.1.tgz",
-      "dev": true
+      "integrity": "sha1-zC8dMjK4yVzBUwRrzhaPK6oRhug=",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.3.4",
+        "cluster-key-slot": "^1.0.6",
+        "debug": "^2.2.0",
+        "denque": "^1.1.0",
+        "flexbuffer": "0.0.6",
+        "lodash": "^4.8.2",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.4.0"
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "from": "is-arrayish@https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-bluebird": {
       "version": "1.0.2",
-      "from": "is-bluebird@https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
+      "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI=",
       "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
-      "from": "is-buffer@https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-callable": {
       "version": "1.1.3",
-      "from": "is-callable@https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
       "dev": true
     },
     "is-date-object": {
       "version": "1.0.1",
-      "from": "is-date-object@https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "from": "is-fullwidth-code-point@https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
     },
     "is-my-json-valid": {
       "version": "2.16.0",
-      "from": "is-my-json-valid@https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "dev": true
+      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "dev": true,
+      "requires": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "from": "is-path-cwd@https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
-      "from": "is-path-in-cwd@https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "^1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.1",
-      "from": "is-path-inside@https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
     },
     "is-property": {
       "version": "1.0.2",
-      "from": "is-property@https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
-      "from": "is-regex@https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "dev": true
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
     },
     "is-resolvable": {
       "version": "1.1.0",
-      "from": "is-resolvable@https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
-      "from": "is-stream@https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.1",
-      "from": "is-symbol@https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "from": "is-typedarray@https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-windows": {
       "version": "1.0.1",
-      "from": "is-windows@https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
+      "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
       "dev": true
     },
     "isarray": {
       "version": "1.0.0",
-      "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "from": "isexe@https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
-      "from": "isstream@https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
-      "from": "js-tokens@https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
       "version": "3.6.1",
-      "from": "js-yaml@https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-      "dev": true
+      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^2.6.0"
+      }
     },
     "js2xmlparser": {
       "version": "3.0.0",
-      "from": "js2xmlparser@https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
+      "dev": true,
+      "requires": {
+        "xmlcreate": "^1.0.1"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
-      "from": "jsbn@https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
     },
     "jsdoc": {
       "version": "3.5.5",
-      "from": "jsdoc@https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
       "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
-      "dev": true
+      "integrity": "sha1-SEUhsSboGQTWMv+D7JqqCWcI+k0=",
+      "dev": true,
+      "requires": {
+        "babylon": "7.0.0-beta.19",
+        "bluebird": "~3.5.0",
+        "catharsis": "~0.8.9",
+        "escape-string-regexp": "~1.0.5",
+        "js2xmlparser": "~3.0.0",
+        "klaw": "~2.0.0",
+        "marked": "~0.3.6",
+        "mkdirp": "~0.5.1",
+        "requizzle": "~0.2.1",
+        "strip-json-comments": "~2.0.1",
+        "taffydb": "2.6.2",
+        "underscore": "~1.8.3"
+      }
     },
     "jsdoc-api": {
       "version": "4.0.1",
-      "from": "jsdoc-api@https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-4.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-NXyQH5P+ABHgCQ08WWxiIxEOmqk=",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "cache-point": "^0.4.1",
+        "collect-all": "^1.0.3",
+        "file-set": "^1.1.1",
+        "fs-then-native": "^2.0.0",
+        "jsdoc": "~3.5.5",
+        "object-to-spawn-args": "^1.1.1",
+        "temp-path": "^1.0.0",
+        "walk-back": "^3.0.0"
+      }
     },
     "jsdoc-parse": {
       "version": "3.0.1",
-      "from": "jsdoc-parse@https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-3.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-EZTWoWot++X7jMz+tQWOqAh1mJM=",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "reduce-extract": "^1.0.0",
+        "sort-array": "^2.0.0",
+        "test-value": "^3.0.0"
+      }
     },
     "jsdoc-to-markdown": {
       "version": "4.0.1",
-      "from": "jsdoc-to-markdown@https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-4.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-JH99l37MIJQoly7JLKFL1OYQNV0=",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "command-line-tool": "^0.8.0",
+        "config-master": "^3.1.0",
+        "dmd": "^3.0.10",
+        "jsdoc-api": "^4.0.1",
+        "jsdoc-parse": "^3.0.1",
+        "walk-back": "^3.0.0"
+      }
     },
     "json-parse-better-errors": {
       "version": "1.0.1",
-      "from": "json-parse-better-errors@https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
       "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
-      "from": "json-schema@https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "from": "json-stable-stringify@https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "from": "json-stringify-safe@https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json3": {
       "version": "3.3.2",
-      "from": "json3@https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
     "jsonify": {
       "version": "0.0.0",
-      "from": "jsonify@https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsonpointer": {
       "version": "4.0.1",
-      "from": "jsonpointer@https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
     "jsprim": {
       "version": "1.4.0",
-      "from": "jsprim@https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.0.2",
+        "json-schema": "0.2.3",
+        "verror": "1.3.6"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "jsx-ast-utils": {
       "version": "1.4.1",
-      "from": "jsx-ast-utils@https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
+      "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
       "dev": true
     },
     "kareem": {
       "version": "1.4.1",
-      "from": "kareem@https://registry.npmjs.org/kareem/-/kareem-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.4.1.tgz",
+      "integrity": "sha1-7XYgAET6BB7zK02oJh4lU/EXNTE=",
       "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
-      "from": "kind-of@https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "dev": true
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
     },
     "klaw": {
       "version": "2.0.0",
-      "from": "klaw@https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "from": "lazy-cache@https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true,
       "optional": true
     },
     "lcov-parse": {
       "version": "0.0.10",
-      "from": "lcov-parse@https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
     },
     "levn": {
       "version": "0.3.0",
-      "from": "levn@https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "dev": true
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
     },
     "load-json-file": {
       "version": "4.0.0",
-      "from": "load-json-file@https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "from": "pify@https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
       }
     },
     "locate-path": {
       "version": "2.0.0",
-      "from": "locate-path@https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
       "dependencies": {
         "path-exists": {
           "version": "3.0.0",
-          "from": "path-exists@https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
       }
     },
     "lodash": {
       "version": "4.17.4",
-      "from": "lodash@https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "from": "lodash._baseassign@https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "dev": true
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "from": "lodash._basecopy@https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basecreate": {
       "version": "3.0.3",
-      "from": "lodash._basecreate@https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
       "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "from": "lodash._getnative@https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "from": "lodash._isiterateecall@https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
-      "from": "lodash.camelcase@https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
-      "from": "lodash.clonedeep@https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.cond": {
       "version": "4.5.2",
-      "from": "lodash.cond@https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
     "lodash.create": {
       "version": "3.1.1",
-      "from": "lodash.create@https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "dev": true
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
+      }
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "from": "lodash.isarguments@https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "from": "lodash.isarray@https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
     "lodash.isobject": {
       "version": "3.0.2",
-      "from": "lodash.isobject@https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "from": "lodash.keys@https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "dev": true
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
     },
     "lodash.omit": {
       "version": "4.5.0",
-      "from": "lodash.omit@https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
       "dev": true
     },
     "lodash.padend": {
       "version": "4.6.1",
-      "from": "lodash.padend@https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
       "dev": true
     },
     "lodash.pick": {
       "version": "4.4.0",
-      "from": "lodash.pick@https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
       "dev": true
     },
     "log-driver": {
       "version": "1.2.5",
-      "from": "log-driver@https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
       "dev": true
     },
     "lolex": {
       "version": "1.6.0",
-      "from": "lolex@https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
       "dev": true
     },
     "longest": {
       "version": "1.0.1",
-      "from": "longest@https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "lru-cache": {
       "version": "4.1.1",
-      "from": "lru-cache@https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "dev": true
+      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "marked": {
       "version": "0.3.12",
-      "from": "marked@https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+      "integrity": "sha1-fPJf8iUmMvP+JAa94ljpTu6SdRk=",
       "dev": true
     },
     "mime-db": {
       "version": "1.27.0",
-      "from": "mime-db@https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.15",
-      "from": "mime-types@https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "dev": true
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "dev": true,
+      "requires": {
+        "mime-db": "~1.27.0"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
-      "from": "minimatch@https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "dev": true
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
     },
     "minimist": {
       "version": "1.2.0",
-      "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
       }
     },
     "mkdirp2": {
       "version": "1.0.3",
-      "from": "mkdirp2@https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.3.tgz",
+      "integrity": "sha1-zI3YJl8fBuLY9bELblL04FC+0hs=",
       "dev": true
     },
     "mocha": {
       "version": "3.4.2",
-      "from": "mocha@https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
+      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
       "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.0",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
       "dependencies": {
         "commander": {
           "version": "2.9.0",
-          "from": "commander@https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "dev": true
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
         },
         "debug": {
           "version": "2.6.0",
-          "from": "debug@https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-          "dev": true
+          "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "ms": {
           "version": "0.7.2",
-          "from": "ms@https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
           "dev": true
         },
         "supports-color": {
           "version": "3.1.2",
-          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "dev": true
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
         }
       }
     },
     "moment": {
       "version": "2.18.1",
-      "from": "moment@https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
       "dev": true
     },
     "moment-timezone": {
       "version": "0.5.13",
-      "from": "moment-timezone@https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz",
-      "dev": true
+      "integrity": "sha1-mc5cfYJyYusPH3AgRBd/YHRde5A=",
+      "dev": true,
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
     },
     "mongodb": {
       "version": "2.2.29",
-      "from": "mongodb@https://registry.npmjs.org/mongodb/-/mongodb-2.2.29.tgz",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.29.tgz",
-      "dev": true
+      "integrity": "sha1-NrJEEm8mdmxevWRluKtbVC1oM8U=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "3.2.1",
+        "mongodb-core": "2.1.13",
+        "readable-stream": "2.2.7"
+      }
     },
     "mongodb-core": {
       "version": "2.1.13",
-      "from": "mongodb-core@https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.13.tgz",
       "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.13.tgz",
-      "dev": true
+      "integrity": "sha1-dx72OCcKyZOrQphGiauCQlG5aog=",
+      "dev": true,
+      "requires": {
+        "bson": "~1.0.4",
+        "require_optional": "~1.0.0"
+      }
     },
     "mongoose": {
       "version": "4.11.1",
-      "from": "mongoose@https://registry.npmjs.org/mongoose/-/mongoose-4.11.1.tgz",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.11.1.tgz",
+      "integrity": "sha1-JWC22J50SwWFfQJMq4sxYGZxbj4=",
       "dev": true,
+      "requires": {
+        "async": "2.1.4",
+        "bson": "~1.0.4",
+        "hooks-fixed": "2.0.0",
+        "kareem": "1.4.1",
+        "mongodb": "2.2.27",
+        "mpath": "0.3.0",
+        "mpromise": "0.5.5",
+        "mquery": "2.3.1",
+        "ms": "2.0.0",
+        "muri": "1.2.1",
+        "regexp-clone": "0.0.1",
+        "sliced": "1.0.1"
+      },
       "dependencies": {
         "mongodb": {
           "version": "2.2.27",
-          "from": "mongodb@https://registry.npmjs.org/mongodb/-/mongodb-2.2.27.tgz",
           "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.27.tgz",
-          "dev": true
+          "integrity": "sha1-NBIgNNtm2YO89qta2yaiSnD+9uY=",
+          "dev": true,
+          "requires": {
+            "es6-promise": "3.2.1",
+            "mongodb-core": "2.1.11",
+            "readable-stream": "2.2.7"
+          }
         },
         "mongodb-core": {
           "version": "2.1.11",
-          "from": "mongodb-core@https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.11.tgz",
           "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.11.tgz",
-          "dev": true
+          "integrity": "sha1-HDh3bOsXSZepnCiGDu2QKNqbPho=",
+          "dev": true,
+          "requires": {
+            "bson": "~1.0.4",
+            "require_optional": "~1.0.0"
+          }
         }
       }
     },
     "mpath": {
       "version": "0.3.0",
-      "from": "mpath@https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz",
+      "integrity": "sha1-elj3iem1/TyUUgY0FXlg8mvV70Q=",
       "dev": true
     },
     "mpromise": {
       "version": "0.5.5",
-      "from": "mpromise@https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
       "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
+      "integrity": "sha1-9bJCWddjrMIlewoMjG2Gb9UXMuY=",
       "dev": true
     },
     "mquery": {
       "version": "2.3.1",
-      "from": "mquery@https://registry.npmjs.org/mquery/-/mquery-2.3.1.tgz",
       "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.3.1.tgz",
+      "integrity": "sha1-mrNnSXFIAP8LtTpoHOS8TV8HyHs=",
       "dev": true,
+      "requires": {
+        "bluebird": "2.10.2",
+        "debug": "2.6.8",
+        "regexp-clone": "0.0.1",
+        "sliced": "0.0.5"
+      },
       "dependencies": {
         "bluebird": {
           "version": "2.10.2",
-          "from": "bluebird@https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
+          "integrity": "sha1-AkpVFylTCIV/FPkfEQb8O1VfRGs=",
           "dev": true
         },
         "sliced": {
           "version": "0.0.5",
-          "from": "sliced@https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
           "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
+          "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8=",
           "dev": true
         }
       }
     },
     "ms": {
       "version": "2.0.0",
-      "from": "ms@https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "muri": {
       "version": "1.2.1",
-      "from": "muri@https://registry.npmjs.org/muri/-/muri-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/muri/-/muri-1.2.1.tgz",
+      "integrity": "sha1-7H6lzmympSPrGrNbrNpfqBbJqjw=",
       "dev": true
     },
     "mute-stream": {
       "version": "0.0.5",
-      "from": "mute-stream@https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
     "native-promise-only": {
       "version": "0.8.1",
-      "from": "native-promise-only@https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
       "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
-      "from": "natural-compare@https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "nock": {
       "version": "9.0.13",
-      "from": "nock@https://registry.npmjs.org/nock/-/nock-9.0.13.tgz",
       "resolved": "https://registry.npmjs.org/nock/-/nock-9.0.13.tgz",
-      "dev": true
+      "integrity": "sha1-0Lw570PTF5mB4isujqBp+RbFeBo=",
+      "dev": true,
+      "requires": {
+        "chai": ">=1.9.2 <4.0.0",
+        "debug": "^2.2.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "~4.17.2",
+        "mkdirp": "^0.5.0",
+        "propagate": "0.4.0",
+        "qs": "^6.0.2"
+      }
     },
     "node-fetch": {
       "version": "1.7.1",
-      "from": "node-fetch@https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz"
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+      "integrity": "sha1-iZyz0KPJL5UsR/G4dvTIrqvUANU=",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
     },
     "node-noop": {
       "version": "1.0.0",
-      "from": "node-noop@https://registry.npmjs.org/node-noop/-/node-noop-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/node-noop/-/node-noop-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/node-noop/-/node-noop-1.0.0.tgz",
+      "integrity": "sha1-R6Pn2Az/qmRYNkvSLthcqzMHvnk="
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "from": "number-is-nan@https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "nyc": {
       "version": "11.0.3",
-      "from": "nyc@https://registry.npmjs.org/nyc/-/nyc-11.0.3.tgz",
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.0.3.tgz",
+      "integrity": "sha1-DCi8ZpqFFiFwm/eghQMDS+44ErY=",
       "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^1.0.0",
+        "convert-source-map": "^1.3.0",
+        "debug-log": "^1.0.1",
+        "default-require-extensions": "^1.0.0",
+        "find-cache-dir": "^0.1.1",
+        "find-up": "^2.1.0",
+        "foreground-child": "^1.5.3",
+        "glob": "^7.0.6",
+        "istanbul-lib-coverage": "^1.1.1",
+        "istanbul-lib-hook": "^1.0.7",
+        "istanbul-lib-instrument": "^1.7.3",
+        "istanbul-lib-report": "^1.1.1",
+        "istanbul-lib-source-maps": "^1.2.1",
+        "istanbul-reports": "^1.1.1",
+        "md5-hex": "^1.2.0",
+        "merge-source-map": "^1.0.2",
+        "micromatch": "^2.3.11",
+        "mkdirp": "^0.5.0",
+        "resolve-from": "^2.0.0",
+        "rimraf": "^2.5.4",
+        "signal-exit": "^3.0.1",
+        "spawn-wrap": "^1.3.7",
+        "test-exclude": "^4.1.1",
+        "yargs": "^8.0.1",
+        "yargs-parser": "^5.0.0"
+      },
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
-          "from": "align-text@>=0.1.3 <0.2.0",
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-          "dev": true
+          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
+          }
         },
         "amdefine": {
           "version": "1.0.1",
-          "from": "amdefine@>=0.0.4",
           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
           "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "from": "ansi-regex@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "from": "ansi-styles@>=2.2.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
-          "from": "append-transform@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-          "dev": true
+          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "^1.0.0"
+          }
         },
         "archy": {
           "version": "1.0.0",
-          "from": "archy@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "arr-diff": {
           "version": "2.0.0",
-          "from": "arr-diff@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "dev": true
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
         },
         "arr-flatten": {
           "version": "1.0.3",
-          "from": "arr-flatten@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
+          "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
           "dev": true
         },
         "array-unique": {
           "version": "0.2.1",
-          "from": "array-unique@>=0.2.1 <0.3.0",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "from": "arrify@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.4.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "babel-code-frame": {
           "version": "6.22.0",
-          "from": "babel-code-frame@>=6.22.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-          "dev": true
+          "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
         },
         "babel-generator": {
           "version": "6.25.0",
-          "from": "babel-generator@>=6.18.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-          "dev": true
+          "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
+          "dev": true,
+          "requires": {
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.25.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.2.0",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
         },
         "babel-messages": {
           "version": "6.23.0",
-          "from": "babel-messages@>=6.23.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-          "dev": true
+          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
         },
         "babel-runtime": {
           "version": "6.23.0",
-          "from": "babel-runtime@>=6.22.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-          "dev": true
+          "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+          "dev": true,
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.10.0"
+          }
         },
         "babel-template": {
           "version": "6.25.0",
-          "from": "babel-template@>=6.16.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-          "dev": true
+          "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.25.0",
+            "babel-types": "^6.25.0",
+            "babylon": "^6.17.2",
+            "lodash": "^4.2.0"
+          }
         },
         "babel-traverse": {
           "version": "6.25.0",
-          "from": "babel-traverse@>=6.18.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-          "dev": true
+          "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "^6.22.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.25.0",
+            "babylon": "^6.17.2",
+            "debug": "^2.2.0",
+            "globals": "^9.0.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.2.0"
+          }
         },
         "babel-types": {
           "version": "6.25.0",
-          "from": "babel-types@>=6.18.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-          "dev": true
+          "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.2.0",
+            "to-fast-properties": "^1.0.1"
+          }
         },
         "babylon": {
           "version": "6.17.4",
-          "from": "babylon@>=6.17.4 <7.0.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+          "integrity": "sha1-Pot0AriNIsNCPhN6FXeIOxX/hpo=",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "from": "balanced-match@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.8",
-          "from": "brace-expansion@>=1.1.7 <2.0.0",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "dev": true
+          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
         },
         "braces": {
           "version": "1.8.5",
-          "from": "braces@>=1.8.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "dev": true
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "from": "builtin-modules@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
           "dev": true
         },
         "caching-transform": {
           "version": "1.0.1",
-          "from": "caching-transform@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-          "dev": true
+          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+          "dev": true,
+          "requires": {
+            "md5-hex": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "write-file-atomic": "^1.1.4"
+          }
         },
         "camelcase": {
           "version": "1.2.1",
-          "from": "camelcase@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
-          "from": "center-align@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
+          }
         },
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dev": true
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
         },
         "cliui": {
           "version": "2.1.0",
-          "from": "cliui@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          },
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "from": "wordwrap@0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
               "dev": true,
               "optional": true
             }
@@ -1939,1106 +2732,1512 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "from": "code-point-at@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "commondir": {
           "version": "1.0.1",
-          "from": "commondir@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "from": "concat-map@0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "convert-source-map": {
           "version": "1.5.0",
-          "from": "convert-source-map@>=1.3.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+          "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
           "dev": true
         },
         "core-js": {
           "version": "2.4.1",
-          "from": "core-js@>=2.4.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+          "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "from": "cross-spawn@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "dev": true
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
         },
         "debug": {
           "version": "2.6.8",
-          "from": "debug@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "dev": true
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "debug-log": {
           "version": "1.0.1",
-          "from": "debug-log@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "from": "decamelize@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "from": "default-require-extensions@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-          "dev": true
+          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+          "dev": true,
+          "requires": {
+            "strip-bom": "^2.0.0"
+          }
         },
         "detect-indent": {
           "version": "4.0.0",
-          "from": "detect-indent@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-          "dev": true
+          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+          "dev": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
         },
         "error-ex": {
           "version": "1.3.1",
-          "from": "error-ex@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "dev": true
+          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+          "dev": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "esutils": {
           "version": "2.0.2",
-          "from": "esutils@>=2.0.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
           "dev": true
         },
         "execa": {
           "version": "0.5.1",
-          "from": "execa@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
-          "dev": true
+          "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^4.0.0",
+            "get-stream": "^2.2.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
         },
         "expand-brackets": {
           "version": "0.1.5",
-          "from": "expand-brackets@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "dev": true
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
         },
         "expand-range": {
           "version": "1.8.2",
-          "from": "expand-range@>=1.8.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-          "dev": true
+          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+          "dev": true,
+          "requires": {
+            "fill-range": "^2.1.0"
+          }
         },
         "extglob": {
           "version": "0.3.2",
-          "from": "extglob@>=0.3.1 <0.4.0",
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "dev": true
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
         },
         "filename-regex": {
           "version": "2.0.1",
-          "from": "filename-regex@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+          "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
           "dev": true
         },
         "fill-range": {
           "version": "2.2.3",
-          "from": "fill-range@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-          "dev": true
+          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+          "dev": true,
+          "requires": {
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
+          }
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "from": "find-cache-dir@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-          "dev": true
+          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
+          }
         },
         "find-up": {
           "version": "2.1.0",
-          "from": "find-up@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "dev": true
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
         },
         "for-in": {
           "version": "1.0.2",
-          "from": "for-in@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
           "dev": true
         },
         "for-own": {
           "version": "0.1.5",
-          "from": "for-own@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-          "dev": true
+          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+          "dev": true,
+          "requires": {
+            "for-in": "^1.0.1"
+          }
         },
         "foreground-child": {
           "version": "1.5.6",
-          "from": "foreground-child@>=1.5.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-          "dev": true
+          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^4",
+            "signal-exit": "^3.0.0"
+          }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "from": "fs.realpath@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "from": "get-caller-file@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
           "dev": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "from": "get-stream@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-          "dev": true
+          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
+          }
         },
         "glob": {
           "version": "7.1.2",
-          "from": "glob@>=7.0.6 <8.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "dev": true
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "glob-base": {
           "version": "0.3.0",
-          "from": "glob-base@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-          "dev": true
+          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+          "dev": true,
+          "requires": {
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
+          }
         },
         "glob-parent": {
           "version": "2.0.0",
-          "from": "glob-parent@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "dev": true
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^2.0.0"
+          }
         },
         "globals": {
           "version": "9.18.0",
-          "from": "globals@>=9.0.0 <10.0.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
           "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "from": "graceful-fs@>=4.1.11 <5.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "handlebars": {
           "version": "4.0.10",
-          "from": "handlebars@>=4.0.3 <5.0.0",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+          "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
           "dev": true,
+          "requires": {
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
+          },
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@>=0.4.4 <0.5.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "dev": true
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "dev": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
             }
           }
         },
         "has-ansi": {
           "version": "2.0.0",
-          "from": "has-ansi@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "dev": true
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
         },
         "has-flag": {
           "version": "1.0.0",
-          "from": "has-flag@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.4.2",
-          "from": "hosted-git-info@>=2.1.4 <3.0.0",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
+          "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "from": "imurmurhash@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "from": "inflight@>=1.0.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "dev": true
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
         },
         "inherits": {
           "version": "2.0.3",
-          "from": "inherits@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "invariant": {
           "version": "2.2.2",
-          "from": "invariant@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-          "dev": true
+          "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
         },
         "invert-kv": {
           "version": "1.0.0",
-          "from": "invert-kv@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
           "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "from": "is-arrayish@>=0.2.1 <0.3.0",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.5",
-          "from": "is-buffer@>=1.1.5 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+          "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "from": "is-builtin-module@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "dev": true
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "dev": true,
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
         },
         "is-dotfile": {
           "version": "1.0.3",
-          "from": "is-dotfile@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+          "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
           "dev": true
         },
         "is-equal-shallow": {
           "version": "0.1.3",
-          "from": "is-equal-shallow@>=0.1.3 <0.2.0",
           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-          "dev": true
+          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+          "dev": true,
+          "requires": {
+            "is-primitive": "^2.0.0"
+          }
         },
         "is-extendable": {
           "version": "0.1.1",
-          "from": "is-extendable@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
           "dev": true
         },
         "is-extglob": {
           "version": "1.0.0",
-          "from": "is-extglob@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-finite": {
           "version": "1.0.2",
-          "from": "is-finite@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-          "dev": true
+          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "dev": true
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
         },
         "is-glob": {
           "version": "2.0.1",
-          "from": "is-glob@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "dev": true
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
         },
         "is-number": {
           "version": "2.1.0",
-          "from": "is-number@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "dev": true
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
         },
         "is-posix-bracket": {
           "version": "0.1.1",
-          "from": "is-posix-bracket@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
           "dev": true
         },
         "is-primitive": {
           "version": "2.0.0",
-          "from": "is-primitive@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "from": "is-stream@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
-          "from": "is-utf8@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "from": "isexe@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "isobject": {
           "version": "2.1.0",
-          "from": "isobject@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "dev": true
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
         },
         "istanbul-lib-coverage": {
           "version": "1.1.1",
-          "from": "istanbul-lib-coverage@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+          "integrity": "sha1-c7+5mIhSmUFck9OKPprfeEp3qdo=",
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.0.7",
-          "from": "istanbul-lib-hook@>=1.0.7 <2.0.0",
           "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
-          "dev": true
+          "integrity": "sha1-3WYH8DB2V4/n1vKmMM8UO0m6zdw=",
+          "dev": true,
+          "requires": {
+            "append-transform": "^0.4.0"
+          }
         },
         "istanbul-lib-instrument": {
           "version": "1.7.3",
-          "from": "istanbul-lib-instrument@>=1.7.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.3.tgz",
-          "dev": true
+          "integrity": "sha1-klsjkWPqvdaMxASPUsL6T4mez6c=",
+          "dev": true,
+          "requires": {
+            "babel-generator": "^6.18.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.18.0",
+            "babel-types": "^6.18.0",
+            "babylon": "^6.17.4",
+            "istanbul-lib-coverage": "^1.1.1",
+            "semver": "^5.3.0"
+          }
         },
         "istanbul-lib-report": {
           "version": "1.1.1",
-          "from": "istanbul-lib-report@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+          "integrity": "sha1-8OVfVmVf+jQiIIC3oM1HYOFAX8k=",
           "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "^1.1.1",
+            "mkdirp": "^0.5.1",
+            "path-parse": "^1.0.5",
+            "supports-color": "^3.1.2"
+          },
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
-              "from": "supports-color@>=3.1.2 <4.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-              "dev": true
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "dev": true,
+              "requires": {
+                "has-flag": "^1.0.0"
+              }
             }
           }
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.1",
-          "from": "istanbul-lib-source-maps@>=1.2.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
-          "dev": true
+          "integrity": "sha1-pv4ay6jOCO68Y45XLilNJnAIqgw=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.6.3",
+            "istanbul-lib-coverage": "^1.1.1",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.6.1",
+            "source-map": "^0.5.3"
+          }
         },
         "istanbul-reports": {
           "version": "1.1.1",
-          "from": "istanbul-reports@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
-          "dev": true
+          "integrity": "sha1-BCvlyJ4XW8P4ZSPKqynAFOd/7k4=",
+          "dev": true,
+          "requires": {
+            "handlebars": "^4.0.3"
+          }
         },
         "js-tokens": {
           "version": "3.0.1",
-          "from": "js-tokens@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+          "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
           "dev": true
         },
         "jsesc": {
           "version": "1.3.0",
-          "from": "jsesc@>=1.3.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "from": "kind-of@>=3.0.2 <4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "dev": true
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "from": "lazy-cache@>=1.0.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
           "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
-          "from": "lcid@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "dev": true
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "dev": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
         },
         "load-json-file": {
           "version": "1.1.0",
-          "from": "load-json-file@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "dev": true
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
         },
         "locate-path": {
           "version": "2.0.0",
-          "from": "locate-path@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          },
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
-              "from": "path-exists@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
               "dev": true
             }
           }
         },
         "lodash": {
           "version": "4.17.4",
-          "from": "lodash@>=4.2.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
         "longest": {
           "version": "1.0.1",
-          "from": "longest@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
           "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
-          "from": "loose-envify@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-          "dev": true
+          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0"
+          }
         },
         "lru-cache": {
           "version": "4.1.1",
-          "from": "lru-cache@>=4.0.1 <5.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "dev": true
+          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
         },
         "md5-hex": {
           "version": "1.3.0",
-          "from": "md5-hex@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-          "dev": true
+          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "^0.1.1"
+          }
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "from": "md5-o-matic@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "from": "mem@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "dev": true
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
         },
         "merge-source-map": {
           "version": "1.0.4",
-          "from": "merge-source-map@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-          "dev": true
+          "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+          "dev": true,
+          "requires": {
+            "source-map": "^0.5.6"
+          }
         },
         "micromatch": {
           "version": "2.3.11",
-          "from": "micromatch@>=2.3.11 <3.0.0",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "dev": true
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          }
         },
         "mimic-fn": {
           "version": "1.1.0",
-          "from": "mimic-fn@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+          "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "from": "minimatch@>=3.0.4 <4.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "dev": true
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
         },
         "minimist": {
           "version": "0.0.8",
-          "from": "minimist@0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dev": true
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.3.8",
-          "from": "normalize-package-data@>=2.3.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-          "dev": true
+          "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
         },
         "normalize-path": {
           "version": "2.1.1",
-          "from": "normalize-path@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "dev": true
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "from": "npm-run-path@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "dev": true
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "from": "number-is-nan@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "from": "object-assign@>=4.1.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "object.omit": {
           "version": "2.0.1",
-          "from": "object.omit@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-          "dev": true
+          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+          "dev": true,
+          "requires": {
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
+          }
         },
         "once": {
           "version": "1.4.0",
-          "from": "once@>=1.3.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "dev": true
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "dev": true
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "dev": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "from": "os-homedir@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "2.0.0",
-          "from": "os-locale@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
-          "dev": true
+          "integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ=",
+          "dev": true,
+          "requires": {
+            "execa": "^0.5.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
         },
         "p-finally": {
           "version": "1.0.0",
-          "from": "p-finally@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
           "version": "1.1.0",
-          "from": "p-limit@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+          "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
           "dev": true
         },
         "p-locate": {
           "version": "2.0.0",
-          "from": "p-locate@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "dev": true
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
         },
         "parse-glob": {
           "version": "3.0.4",
-          "from": "parse-glob@>=3.0.4 <4.0.0",
           "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-          "dev": true
+          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+          "dev": true,
+          "requires": {
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
+          }
         },
         "parse-json": {
           "version": "2.2.0",
-          "from": "parse-json@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "dev": true
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
         },
         "path-exists": {
           "version": "2.1.0",
-          "from": "path-exists@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "dev": true
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "from": "path-key@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "from": "path-parse@>=1.0.5 <2.0.0",
           "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
           "dev": true
         },
         "path-type": {
           "version": "1.1.0",
-          "from": "path-type@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "dev": true
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
         },
         "pify": {
           "version": "2.3.0",
-          "from": "pify@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "from": "pinkie@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "from": "pinkie-promise@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "dev": true
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "dev": true,
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "from": "pkg-dir@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
+          "requires": {
+            "find-up": "^1.0.0"
+          },
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "from": "find-up@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "dev": true
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "dev": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
             }
           }
         },
         "preserve": {
           "version": "0.2.0",
-          "from": "preserve@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "from": "pseudomap@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "randomatic": {
           "version": "1.1.7",
-          "from": "randomatic@>=1.1.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+          "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
           "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "from": "is-number@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "from": "kind-of@^3.0.2",
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "dev": true
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
                 }
               }
             },
             "kind-of": {
               "version": "4.0.0",
-              "from": "kind-of@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-              "dev": true
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
             }
           }
         },
         "read-pkg": {
           "version": "1.1.0",
-          "from": "read-pkg@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "dev": true
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "from": "read-pkg-up@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          },
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "from": "find-up@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "dev": true
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "dev": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
             }
           }
         },
         "regenerator-runtime": {
           "version": "0.10.5",
-          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
           "dev": true
         },
         "regex-cache": {
           "version": "0.4.3",
-          "from": "regex-cache@>=0.4.2 <0.5.0",
           "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-          "dev": true
+          "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+          "dev": true,
+          "requires": {
+            "is-equal-shallow": "^0.1.3",
+            "is-primitive": "^2.0.0"
+          }
         },
         "remove-trailing-separator": {
           "version": "1.0.2",
-          "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+          "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
           "dev": true
         },
         "repeat-element": {
           "version": "1.1.2",
-          "from": "repeat-element@>=1.1.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
           "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "from": "repeat-string@>=1.5.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
           "dev": true
         },
         "repeating": {
           "version": "2.0.1",
-          "from": "repeating@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-          "dev": true
+          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+          "dev": true,
+          "requires": {
+            "is-finite": "^1.0.0"
+          }
         },
         "require-directory": {
           "version": "2.1.1",
-          "from": "require-directory@>=2.1.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "from": "require-main-filename@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "from": "resolve-from@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
-          "from": "right-align@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.1"
+          }
         },
         "rimraf": {
           "version": "2.6.1",
-          "from": "rimraf@>=2.5.4 <3.0.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "dev": true
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
         },
         "semver": {
           "version": "5.3.0",
-          "from": "semver@>=5.3.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "from": "set-blocking@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "from": "signal-exit@>=3.0.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "from": "slide@>=1.1.5 <2.0.0",
           "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.6",
-          "from": "source-map@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.3.7",
-          "from": "spawn-wrap@>=1.3.7 <2.0.0",
           "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.7.tgz",
-          "dev": true
+          "integrity": "sha1-vri/RCbWSysGhx4Nfe4mQ/H40bw=",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^1.5.6",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.3.3",
+            "signal-exit": "^3.0.2",
+            "which": "^1.2.4"
+          }
         },
         "spdx-correct": {
           "version": "1.0.2",
-          "from": "spdx-correct@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-          "dev": true
+          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "^1.0.2"
+          }
         },
         "spdx-expression-parse": {
           "version": "1.0.4",
-          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
           "dev": true
         },
         "spdx-license-ids": {
           "version": "1.2.2",
-          "from": "spdx-license-ids@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
           "dev": true
         },
         "string-width": {
           "version": "2.0.0",
-          "from": "string-width@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
           "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^3.0.0"
+          },
           "dependencies": {
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             }
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "from": "strip-ansi@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "dev": true
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
         },
         "strip-bom": {
           "version": "2.0.0",
-          "from": "strip-bom@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "dev": true
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
         },
         "strip-eof": {
           "version": "1.0.0",
-          "from": "strip-eof@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "from": "supports-color@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "test-exclude": {
           "version": "4.1.1",
-          "from": "test-exclude@>=4.1.1 <5.0.0",
           "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-          "dev": true
+          "integrity": "sha1-TYSWSwlmsAh+zDNKLOAC09k0HiY=",
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "micromatch": "^2.3.11",
+            "object-assign": "^4.1.0",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
+          }
         },
         "to-fast-properties": {
           "version": "1.0.3",
-          "from": "to-fast-properties@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
         },
         "trim-right": {
           "version": "1.0.1",
-          "from": "trim-right@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
           "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
-          "from": "uglify-js@>=2.6.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          },
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "from": "yargs@>=3.10.0 <3.11.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "dev": true,
-              "optional": true
+              "optional": true,
+              "requires": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
+              }
             }
           }
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
           "dev": true,
           "optional": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "dev": true
+          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "dev": true,
+          "requires": {
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
+          }
         },
         "which": {
           "version": "1.2.14",
-          "from": "which@>=1.2.9 <2.0.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "dev": true
+          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         },
         "which-module": {
           "version": "2.0.0",
-          "from": "which-module@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
-          "from": "window-size@0.1.0",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "from": "wordwrap@>=0.0.2 <0.1.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "from": "wrap-ansi@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "from": "string-width@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "dev": true
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
             }
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "from": "wrappy@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
-          "from": "write-file-atomic@>=1.1.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "dev": true
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
+          }
         },
         "y18n": {
           "version": "3.2.1",
-          "from": "y18n@>=3.2.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "from": "yallist@>=2.1.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
           "version": "8.0.2",
-          "from": "yargs@>=8.0.1 <9.0.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
+          },
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "from": "camelcase@>=4.1.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             },
             "cliui": {
               "version": "3.2.0",
-              "from": "cliui@>=3.2.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
               "dev": true,
+              "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
+              },
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
-                  "from": "string-width@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "dev": true
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
+                  }
                 }
               }
             },
             "load-json-file": {
               "version": "2.0.0",
-              "from": "load-json-file@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-              "dev": true
+              "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "strip-bom": "^3.0.0"
+              }
             },
             "path-type": {
               "version": "2.0.0",
-              "from": "path-type@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-              "dev": true
+              "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+              "dev": true,
+              "requires": {
+                "pify": "^2.0.0"
+              }
             },
             "read-pkg": {
               "version": "2.0.0",
-              "from": "read-pkg@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-              "dev": true
+              "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+              "dev": true,
+              "requires": {
+                "load-json-file": "^2.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^2.0.0"
+              }
             },
             "read-pkg-up": {
               "version": "2.0.0",
-              "from": "read-pkg-up@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-              "dev": true
+              "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+              "dev": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^2.0.0"
+              }
             },
             "strip-bom": {
               "version": "3.0.0",
-              "from": "strip-bom@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
               "dev": true
             },
             "yargs-parser": {
               "version": "7.0.0",
-              "from": "yargs-parser@>=7.0.0 <8.0.0",
               "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-              "dev": true
+              "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+              "dev": true,
+              "requires": {
+                "camelcase": "^4.1.0"
+              }
             }
           }
         },
         "yargs-parser": {
           "version": "5.0.0",
-          "from": "yargs-parser@>=5.0.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0"
+          },
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
-              "from": "camelcase@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
               "dev": true
             }
           }
@@ -3047,777 +4246,1065 @@
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "from": "oauth-sign@https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-get": {
       "version": "2.1.0",
-      "from": "object-get@https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
+      "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4=",
       "dev": true
     },
     "object-keys": {
       "version": "1.0.11",
-      "from": "object-keys@https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
     },
     "object-to-spawn-args": {
       "version": "1.1.1",
-      "from": "object-to-spawn-args@https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
+      "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=",
       "dev": true
     },
     "object.assign": {
       "version": "4.1.0",
-      "from": "object.assign@https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "dev": true
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
     },
     "once": {
       "version": "1.4.0",
-      "from": "once@https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "dev": true
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
     },
     "onetime": {
       "version": "1.1.0",
-      "from": "onetime@https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
     "optimist": {
       "version": "0.6.1",
-      "from": "optimist@https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "from": "minimist@>=0.0.1 <0.1.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "from": "wordwrap@>=0.0.2 <0.1.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
       }
     },
     "optionator": {
       "version": "0.8.2",
-      "from": "optionator@https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "dev": true
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
     },
     "os-homedir": {
       "version": "1.0.2",
-      "from": "os-homedir@https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "p-limit": {
       "version": "1.2.0",
-      "from": "p-limit@https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-      "dev": true
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
-      "from": "p-locate@https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
     },
     "p-try": {
       "version": "1.0.0",
-      "from": "p-try@https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
     "parse-json": {
       "version": "4.0.0",
-      "from": "parse-json@https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
     },
     "path-exists": {
       "version": "2.1.0",
-      "from": "path-exists@https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "dev": true
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "from": "path-is-absolute@https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "from": "path-is-inside@https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
-      "from": "path-parse@https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "path-to-regexp": {
       "version": "1.7.0",
-      "from": "path-to-regexp@https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
       "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         }
       }
     },
     "pify": {
       "version": "2.3.0",
-      "from": "pify@https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
-      "from": "pinkie@https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "from": "pinkie-promise@https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
     },
     "pkg-conf": {
       "version": "2.1.0",
-      "from": "pkg-conf@https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+      "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
       "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "load-json-file": "^4.0.0"
+      },
       "dependencies": {
         "find-up": {
           "version": "2.1.0",
-          "from": "find-up@https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "dev": true
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
         }
       }
     },
     "pkg-config": {
       "version": "1.1.1",
-      "from": "pkg-config@https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
-      "dev": true
+      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+      "dev": true,
+      "requires": {
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
+      }
     },
     "pkg-dir": {
       "version": "1.0.0",
-      "from": "pkg-dir@https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0"
+      }
     },
     "pkg-up": {
       "version": "1.0.0",
-      "from": "pkg-up@https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0"
+      }
     },
     "pluralize": {
       "version": "1.2.1",
-      "from": "pluralize@https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
     },
     "precond": {
       "version": "0.2.3",
-      "from": "precond@https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "from": "prelude-ls@https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "1.0.7",
-      "from": "process-nextick-args@https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
     },
     "progress": {
       "version": "1.1.8",
-      "from": "progress@https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
     "propagate": {
       "version": "0.4.0",
-      "from": "propagate@https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
+      "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE=",
       "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
-      "from": "pseudomap@https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "punycode": {
       "version": "1.4.1",
-      "from": "punycode@https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
     "qs": {
       "version": "6.3.2",
-      "from": "qs@https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
       "dev": true
     },
     "readable-stream": {
       "version": "2.2.7",
-      "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
-      "dev": true
+      "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+      "dev": true,
+      "requires": {
+        "buffer-shims": "~1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~1.0.0",
+        "util-deprecate": "~1.0.1"
+      }
     },
     "readline2": {
       "version": "1.0.1",
-      "from": "readline2@https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "mute-stream": "0.0.5"
+      }
     },
     "rechoir": {
       "version": "0.6.2",
-      "from": "rechoir@https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "dev": true
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
     },
     "redis-commands": {
       "version": "1.3.1",
-      "from": "redis-commands@https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
+      "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs=",
       "dev": true
     },
     "redis-parser": {
       "version": "2.6.0",
-      "from": "redis-parser@https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=",
       "dev": true
     },
     "reduce-extract": {
       "version": "1.0.0",
-      "from": "reduce-extract@https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
+      "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
       "dev": true,
+      "requires": {
+        "test-value": "^1.0.1"
+      },
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "from": "array-back@https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "dev": true
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
+          "requires": {
+            "typical": "^2.6.0"
+          }
         },
         "test-value": {
           "version": "1.1.0",
-          "from": "test-value@https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "dev": true
+          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+          "dev": true,
+          "requires": {
+            "array-back": "^1.0.2",
+            "typical": "^2.4.2"
+          }
         }
       }
     },
     "reduce-flatten": {
       "version": "1.0.1",
-      "from": "reduce-flatten@https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
+      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
       "dev": true
     },
     "reduce-unique": {
       "version": "1.0.0",
-      "from": "reduce-unique@https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz",
+      "integrity": "sha1-flhrz4ek4ytter2Cd/rWzeyfSAM=",
       "dev": true
     },
     "reduce-without": {
       "version": "1.0.1",
-      "from": "reduce-without@https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
+      "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
       "dev": true,
+      "requires": {
+        "test-value": "^2.0.0"
+      },
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "from": "array-back@https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "dev": true
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
+          "requires": {
+            "typical": "^2.6.0"
+          }
         },
         "test-value": {
           "version": "2.1.0",
-          "from": "test-value@https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-          "dev": true
+          "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+          "dev": true,
+          "requires": {
+            "array-back": "^1.0.3",
+            "typical": "^2.6.0"
+          }
         }
       }
     },
     "regexp-clone": {
       "version": "0.0.1",
-      "from": "regexp-clone@https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
+      "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "from": "repeat-string@https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "request": {
       "version": "2.79.0",
-      "from": "request@https://registry.npmjs.org/request/-/request-2.79.0.tgz",
       "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-      "dev": true
-    },
-    "require_optional": {
-      "version": "1.0.1",
-      "from": "require_optional@https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.6.0",
+        "aws4": "^1.2.1",
+        "caseless": "~0.11.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.1.1",
+        "har-validator": "~2.0.6",
+        "hawk": "~3.1.3",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "oauth-sign": "~0.8.1",
+        "qs": "~6.3.0",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.3.0",
+        "tunnel-agent": "~0.4.1",
+        "uuid": "^3.0.0"
+      }
     },
     "require-uncached": {
       "version": "1.0.3",
-      "from": "require-uncached@https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      },
       "dependencies": {
         "resolve-from": {
           "version": "1.0.1",
-          "from": "resolve-from@https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
           "dev": true
         }
       }
     },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha1-TPNaQkf2TKPfjC7yCMxJSxyo/C4=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      }
+    },
     "requizzle": {
       "version": "0.2.1",
-      "from": "requizzle@https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
+      "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
       "dev": true,
+      "requires": {
+        "underscore": "~1.6.0"
+      },
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
           "dev": true
         }
       }
     },
     "resolve": {
       "version": "1.5.0",
-      "from": "resolve@https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "dev": true
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.5"
+      }
     },
     "resolve-from": {
       "version": "2.0.0",
-      "from": "resolve-from@https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
       "dev": true
     },
     "restore-cursor": {
       "version": "1.0.1",
-      "from": "restore-cursor@https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
+      }
     },
     "retry-as-promised": {
       "version": "2.2.0",
-      "from": "retry-as-promised@https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.2.0.tgz",
-      "dev": true
+      "integrity": "sha1-sEY9f9PPWy/tZFAKtui4pJxbjmw=",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.4.6",
+        "cross-env": "^3.1.2",
+        "debug": "^2.2.0"
+      }
     },
     "right-align": {
       "version": "0.1.3",
-      "from": "right-align@https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "^0.1.1"
+      }
     },
     "rimraf": {
       "version": "2.6.2",
-      "from": "rimraf@https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "dev": true
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5"
+      }
     },
     "run-async": {
       "version": "0.1.0",
-      "from": "run-async@https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "dev": true
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0"
+      }
     },
     "run-parallel": {
       "version": "1.1.6",
-      "from": "run-parallel@https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
+      "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk=",
       "dev": true
     },
     "rx-lite": {
       "version": "3.1.2",
-      "from": "rx-lite@https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
       "dev": true
     },
     "safe-buffer": {
       "version": "5.1.1",
-      "from": "safe-buffer@https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
       "dev": true
     },
     "samsam": {
       "version": "1.2.1",
-      "from": "samsam@https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
+      "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
       "dev": true
     },
     "semver": {
       "version": "5.3.0",
-      "from": "semver@https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
     },
     "sequelize": {
       "version": "4.2.1",
-      "from": "sequelize@https://registry.npmjs.org/sequelize/-/sequelize-4.2.1.tgz",
       "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.2.1.tgz",
-      "dev": true
+      "integrity": "sha1-F/4cWwWDZO/6mrRiTWu3AU9HIkE=",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.4.6",
+        "cls-bluebird": "^2.0.1",
+        "debug": "^2.3.0",
+        "depd": "^1.1.0",
+        "dottie": "^2.0.0",
+        "env-cmd": "^5.0.0",
+        "generic-pool": "^3.1.6",
+        "inflection": "1.10.0",
+        "lodash": "^4.17.1",
+        "moment": "^2.13.0",
+        "moment-timezone": "^0.5.4",
+        "retry-as-promised": "^2.0.0",
+        "semver": "^5.0.1",
+        "terraformer-wkt-parser": "^1.1.2",
+        "toposort-class": "^1.0.1",
+        "uuid": "^3.0.0",
+        "validator": "^6.3.0",
+        "wkx": "^0.4.1"
+      }
     },
     "shebang-command": {
       "version": "1.2.0",
-      "from": "shebang-command@https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "dev": true
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "from": "shebang-regex@https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "shelljs": {
       "version": "0.7.8",
-      "from": "shelljs@https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "dev": true
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "shimmer": {
       "version": "1.1.0",
-      "from": "shimmer@https://registry.npmjs.org/shimmer/-/shimmer-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.1.0.tgz",
+      "integrity": "sha1-l9c3cTf/u6tCVSLkKf4KqJpIizU=",
       "dev": true
     },
     "sinon": {
       "version": "2.3.6",
-      "from": "sinon@https://registry.npmjs.org/sinon/-/sinon-2.3.6.tgz",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.6.tgz",
+      "integrity": "sha1-lTeOfg+XapcS6bRZH/WznnPcPd4=",
       "dev": true,
+      "requires": {
+        "diff": "^3.1.0",
+        "formatio": "1.2.0",
+        "lolex": "^1.6.0",
+        "native-promise-only": "^0.8.1",
+        "path-to-regexp": "^1.7.0",
+        "samsam": "^1.1.3",
+        "text-encoding": "0.6.4",
+        "type-detect": "^4.0.0"
+      },
       "dependencies": {
         "type-detect": {
           "version": "4.0.3",
-          "from": "type-detect@https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+          "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
           "dev": true
         }
       }
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "from": "slice-ansi@https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
     "sliced": {
       "version": "1.0.1",
-      "from": "sliced@https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=",
       "dev": true
     },
     "sntp": {
       "version": "1.0.9",
-      "from": "sntp@https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "dev": true
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.x.x"
+      }
     },
     "sort-array": {
       "version": "2.0.0",
-      "from": "sort-array@https://registry.npmjs.org/sort-array/-/sort-array-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-2.0.0.tgz",
+      "integrity": "sha1-OKnG2if9fRR7QuYFVPKBGHtN9HI=",
       "dev": true,
+      "requires": {
+        "array-back": "^1.0.4",
+        "object-get": "^2.1.0",
+        "typical": "^2.6.0"
+      },
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "from": "array-back@https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "dev": true
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
+          "requires": {
+            "typical": "^2.6.0"
+          }
         }
       }
     },
     "source-map": {
       "version": "0.4.4",
-      "from": "source-map@https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "dev": true
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "dev": true,
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "from": "sprintf-js@https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
       "version": "1.13.1",
-      "from": "sshpk@https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "standard": {
       "version": "10.0.3",
-      "from": "standard@https://registry.npmjs.org/standard/-/standard-10.0.3.tgz",
       "resolved": "https://registry.npmjs.org/standard/-/standard-10.0.3.tgz",
-      "dev": true
+      "integrity": "sha512-JURZ+85ExKLQULckDFijdX5WHzN6RC7fgiZNSV4jFQVo+3tPoQGHyBrGekye/yf0aOfb4210EM5qPNlc2cRh4w==",
+      "dev": true,
+      "requires": {
+        "eslint": "~3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-config-standard-jsx": "4.0.2",
+        "eslint-plugin-import": "~2.2.0",
+        "eslint-plugin-node": "~4.2.2",
+        "eslint-plugin-promise": "~3.5.0",
+        "eslint-plugin-react": "~6.10.0",
+        "eslint-plugin-standard": "~3.0.1",
+        "standard-engine": "~7.0.0"
+      }
     },
     "standard-engine": {
       "version": "7.0.0",
-      "from": "standard-engine@https://registry.npmjs.org/standard-engine/-/standard-engine-7.0.0.tgz",
       "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-7.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-67d7nI/CyBZf+jU72Rug3/Qa9pA=",
+      "dev": true,
+      "requires": {
+        "deglob": "^2.1.0",
+        "get-stdin": "^5.0.1",
+        "minimist": "^1.1.0",
+        "pkg-conf": "^2.0.0"
+      }
     },
     "stream-connect": {
       "version": "1.0.2",
-      "from": "stream-connect@https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
+      "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
       "dev": true,
+      "requires": {
+        "array-back": "^1.0.2"
+      },
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
-          "from": "array-back@https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "dev": true
+          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "dev": true,
+          "requires": {
+            "typical": "^2.6.0"
+          }
         }
       }
     },
     "stream-via": {
       "version": "1.0.4",
-      "from": "stream-via@https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
-      "dev": true
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "from": "string_decoder@https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-jcy7CskJMo64vI4qS9OTSv2vYGw=",
       "dev": true
     },
     "string-width": {
       "version": "1.0.2",
-      "from": "string-width@https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "dev": true
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
-      "from": "stringstream@https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
       "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "from": "strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "dev": true
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
     },
     "strip-bom": {
       "version": "3.0.0",
-      "from": "strip-bom@https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "from": "strip-json-comments@https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
-      "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
     "table": {
       "version": "3.8.3",
-      "from": "table@https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
+      "requires": {
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.0.0",
+        "slice-ansi": "0.0.4",
+        "string-width": "^2.0.0"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "from": "ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "from": "is-fullwidth-code-point@https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "from": "string-width@https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "dev": true
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "from": "strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "dev": true
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
         }
       }
     },
     "table-layout": {
       "version": "0.4.2",
-      "from": "table-layout@https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
-      "dev": true
+      "integrity": "sha1-EOkEPBQqHi0VXaclfkePDvSYF4Y=",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "deep-extend": "~0.5.0",
+        "lodash.padend": "^4.6.1",
+        "typical": "^2.6.1",
+        "wordwrapjs": "^3.0.0"
+      }
     },
     "taffydb": {
       "version": "2.6.2",
-      "from": "taffydb@https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
     },
     "temp-path": {
       "version": "1.0.0",
-      "from": "temp-path@https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
+      "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=",
       "dev": true
     },
     "terraformer": {
       "version": "1.0.8",
-      "from": "terraformer@https://registry.npmjs.org/terraformer/-/terraformer-1.0.8.tgz",
       "resolved": "https://registry.npmjs.org/terraformer/-/terraformer-1.0.8.tgz",
-      "dev": true
+      "integrity": "sha1-UeCtiXRvzyFh3G9lqnDkI3fItZM=",
+      "dev": true,
+      "requires": {
+        "@types/geojson": "^1.0.0"
+      }
     },
     "terraformer-wkt-parser": {
       "version": "1.1.2",
-      "from": "terraformer-wkt-parser@https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.1.2.tgz",
-      "dev": true
+      "integrity": "sha1-M2oMj8gglKWv+DKI9prt7NNpvww=",
+      "dev": true,
+      "requires": {
+        "terraformer": "~1.0.5"
+      }
     },
     "test-value": {
       "version": "3.0.0",
-      "from": "test-value@https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-kWjAYvqxGoa41ETdlou0tzhRzpI=",
+      "dev": true,
+      "requires": {
+        "array-back": "^2.0.0",
+        "typical": "^2.6.1"
+      }
     },
     "text-encoding": {
       "version": "0.6.4",
-      "from": "text-encoding@https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
     "text-table": {
       "version": "0.2.0",
-      "from": "text-table@https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "toposort-class": {
       "version": "1.0.1",
-      "from": "toposort-class@https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
+      "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg=",
       "dev": true
     },
     "tough-cookie": {
       "version": "2.3.2",
-      "from": "tough-cookie@https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "dev": true
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "dev": true,
+      "requires": {
+        "punycode": "^1.4.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.4.3",
-      "from": "tunnel-agent@https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
       "dev": true
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "from": "tweetnacl@https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
     },
     "type-check": {
       "version": "0.3.2",
-      "from": "type-check@https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "dev": true
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
     },
     "type-detect": {
       "version": "1.0.0",
-      "from": "type-detect@https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
       "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
-      "from": "typedarray@https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "typical": {
       "version": "2.6.1",
-      "from": "typical@https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
       "dev": true
     },
     "uglify-js": {
       "version": "2.8.29",
-      "from": "uglify-js@https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "from": "source-map@https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true,
           "optional": true
         }
@@ -3825,145 +5312,173 @@
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "from": "uglify-to-browserify@https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
     },
     "underscore": {
       "version": "1.8.3",
-      "from": "underscore@https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
       "dev": true
     },
     "underscore-contrib": {
       "version": "0.3.0",
-      "from": "underscore-contrib@https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+      "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
       "dev": true,
+      "requires": {
+        "underscore": "1.6.0"
+      },
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
           "dev": true
         }
       }
     },
     "uniq": {
       "version": "1.0.1",
-      "from": "uniq@https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
     "user-home": {
       "version": "2.0.0",
-      "from": "user-home@https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "from": "util-deprecate@https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "uuid": {
       "version": "3.1.0",
-      "from": "uuid@https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
       "dev": true
     },
     "uuid4": {
       "version": "1.0.0",
-      "from": "uuid4@https://registry.npmjs.org/uuid4/-/uuid4-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/uuid4/-/uuid4-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/uuid4/-/uuid4-1.0.0.tgz",
+      "integrity": "sha1-gTqurxHqL2iQnFrVfYlPgyAtZyA="
     },
     "validator": {
       "version": "6.3.0",
-      "from": "validator@https://registry.npmjs.org/validator/-/validator-6.3.0.tgz",
       "resolved": "https://registry.npmjs.org/validator/-/validator-6.3.0.tgz",
+      "integrity": "sha1-R84j7Y1Ord+p1LjvAHG2zxB418g=",
       "dev": true
     },
     "verror": {
       "version": "1.3.6",
-      "from": "verror@https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "dev": true
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "dev": true,
+      "requires": {
+        "extsprintf": "1.0.2"
+      }
     },
     "walk-back": {
       "version": "3.0.0",
-      "from": "walk-back@https://registry.npmjs.org/walk-back/-/walk-back-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-3.0.0.tgz",
+      "integrity": "sha1-I1h4ejXakQMtrV6S+AsSNw2HlcU=",
       "dev": true
     },
     "which": {
       "version": "1.2.14",
-      "from": "which@https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "dev": true
+      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "window-size": {
       "version": "0.1.0",
-      "from": "window-size@https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true,
       "optional": true
     },
     "wkx": {
       "version": "0.4.1",
-      "from": "wkx@https://registry.npmjs.org/wkx/-/wkx-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.1.tgz",
-      "dev": true
+      "integrity": "sha1-L8FxtenLVcYlb+9L3h8hvkE77+4=",
+      "dev": true,
+      "requires": {
+        "@types/node": "^6.0.48"
+      }
     },
     "wordwrap": {
       "version": "1.0.0",
-      "from": "wordwrap@https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wordwrapjs": {
       "version": "3.0.0",
-      "from": "wordwrapjs@https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-      "dev": true
+      "integrity": "sha1-yUw3KJTK3G/rGma/9k4dmvksXR4=",
+      "dev": true,
+      "requires": {
+        "reduce-flatten": "^1.0.1",
+        "typical": "^2.6.1"
+      }
     },
     "wrappy": {
       "version": "1.0.2",
-      "from": "wrappy@https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write": {
       "version": "0.2.1",
-      "from": "write@https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "dev": true
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "xmlcreate": {
       "version": "1.0.2",
-      "from": "xmlcreate@https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
+      "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
       "dev": true
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
     "yallist": {
       "version": "2.1.2",
-      "from": "yallist@https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {
       "version": "3.10.0",
-      "from": "yargs@https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0"
+      }
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,2713 +1,1937 @@
 {
   "name": "@fresh8/copacetic",
   "version": "3.6.1",
-  "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "@types/geojson": {
       "version": "1.0.2",
+      "from": "@types/geojson@https://registry.npmjs.org/@types/geojson/-/geojson-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.2.tgz",
-      "integrity": "sha1-sC0QqwKOKSisWSoFGqpJgaGUHQM=",
       "dev": true
     },
     "@types/node": {
       "version": "6.0.79",
+      "from": "@types/node@https://registry.npmjs.org/@types/node/-/node-6.0.79.tgz",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.79.tgz",
-      "integrity": "sha1-Xv59Sm2MRTx+nq9V2TH0oi+sUWk=",
       "dev": true
     },
     "acorn": {
       "version": "5.3.0",
+      "from": "acorn@https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
       "dev": true
     },
     "acorn-jsx": {
       "version": "3.0.1",
+      "from": "acorn-jsx@https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
-      "requires": {
-        "acorn": "3.3.0"
-      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
+          "from": "acorn@https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
       }
     },
     "ajv": {
       "version": "4.11.8",
+      "from": "ajv@https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true,
-      "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
-      }
+      "dev": true
     },
     "ajv-keywords": {
       "version": "1.5.1",
+      "from": "ajv-keywords@https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
     },
     "align-text": {
       "version": "0.1.4",
+      "from": "align-text@https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      }
+      "dev": true
     },
     "amdefine": {
       "version": "1.0.1",
+      "from": "amdefine@https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
     "ansi-escape-sequences": {
       "version": "4.0.0",
+      "from": "ansi-escape-sequences@https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
-      "integrity": "sha1-4OywQpWLceQpQtNcH88dmwCg9n4=",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0"
-      }
+      "dev": true
     },
     "ansi-escapes": {
       "version": "1.4.0",
+      "from": "ansi-escapes@https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
+      "from": "ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
+      "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "argparse": {
       "version": "1.0.9",
+      "from": "argparse@https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "1.0.3"
-      }
+      "dev": true
     },
     "argv-tools": {
       "version": "0.1.1",
+      "from": "argv-tools@https://registry.npmjs.org/argv-tools/-/argv-tools-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/argv-tools/-/argv-tools-0.1.1.tgz",
-      "integrity": "sha1-WIKD8zk62kcUFECxKYHNQb9rcDI=",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0",
-        "find-replace": "2.0.1"
-      }
+      "dev": true
     },
     "array-back": {
       "version": "2.0.0",
+      "from": "array-back@https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-      "integrity": "sha1-aHdHHVHsycm/phNvtsfV/ml0gCI=",
-      "dev": true,
-      "requires": {
-        "typical": "2.6.1"
-      }
+      "dev": true
     },
     "array-union": {
       "version": "1.0.2",
+      "from": "array-union@https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
+      "dev": true
     },
     "array-uniq": {
       "version": "1.0.3",
+      "from": "array-uniq@https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array.prototype.find": {
       "version": "2.0.4",
+      "from": "array.prototype.find@https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
       "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
-      "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0"
-      }
+      "dev": true
     },
     "arrify": {
       "version": "1.0.1",
+      "from": "arrify@https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asn1": {
       "version": "0.2.3",
+      "from": "asn1@https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
       "dev": true
     },
     "assert-plus": {
       "version": "0.2.0",
+      "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
       "dev": true
     },
     "assertion-error": {
       "version": "1.0.2",
+      "from": "assertion-error@https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
     },
     "async": {
       "version": "2.1.4",
+      "from": "async@https://registry.npmjs.org/async/-/async-2.1.4.tgz",
       "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
-      "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4"
-      }
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
+      "from": "asynckit@https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "aws-sign2": {
       "version": "0.6.0",
+      "from": "aws-sign2@https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
       "dev": true
     },
     "aws4": {
       "version": "1.6.0",
+      "from": "aws4@https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
+      "from": "babel-code-frame@https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      }
+      "dev": true
     },
     "babylon": {
       "version": "7.0.0-beta.19",
+      "from": "babylon@https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-      "integrity": "sha1-6SjH6AfpcOBTaweKs+DEj54FJQM=",
       "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
+      "from": "balanced-match@https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
+      "from": "bcrypt-pbkdf@https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
+      "optional": true
     },
     "bluebird": {
       "version": "3.5.0",
+      "from": "bluebird@https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
       "dev": true
     },
     "boom": {
       "version": "2.10.1",
+      "from": "boom@https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.8",
+      "from": "brace-expansion@https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      }
+      "dev": true
     },
     "browser-stdout": {
       "version": "1.3.0",
+      "from": "browser-stdout@https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
     "bson": {
       "version": "1.0.4",
+      "from": "bson@https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
-      "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw=",
       "dev": true
     },
     "buffer-shims": {
       "version": "1.0.0",
+      "from": "buffer-shims@https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
       "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
+      "from": "builtin-modules@https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "cache-point": {
       "version": "0.4.1",
+      "from": "cache-point@https://registry.npmjs.org/cache-point/-/cache-point-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-0.4.1.tgz",
-      "integrity": "sha1-zIycvZnZDXsMZpEM0z13oaq4hA4=",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0",
-        "fs-then-native": "2.0.0",
-        "mkdirp2": "1.0.3"
-      }
+      "dev": true
     },
     "caller-path": {
       "version": "0.1.0",
+      "from": "caller-path@https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "0.2.0"
-      }
+      "dev": true
     },
     "callsites": {
       "version": "0.2.0",
+      "from": "callsites@https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
     "camelcase": {
       "version": "1.2.1",
+      "from": "camelcase@https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true,
       "optional": true
     },
     "caseless": {
       "version": "0.11.0",
+      "from": "caseless@https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
       "dev": true
     },
     "catharsis": {
       "version": "0.8.9",
+      "from": "catharsis@https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
-      "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
-      "dev": true,
-      "requires": {
-        "underscore-contrib": "0.3.0"
-      }
+      "dev": true
     },
     "center-align": {
       "version": "0.1.3",
+      "from": "center-align@https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      }
+      "optional": true
     },
     "chai": {
       "version": "3.5.0",
+      "from": "chai@https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-      "dev": true,
-      "requires": {
-        "assertion-error": "1.0.2",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
-      }
+      "dev": true
     },
     "chalk": {
       "version": "1.1.3",
+      "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
-      }
+      "dev": true
     },
     "circular-json": {
       "version": "0.3.3",
+      "from": "circular-json@https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli-cursor": {
       "version": "1.0.2",
+      "from": "cli-cursor@https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "1.0.1"
-      }
+      "dev": true
     },
     "cli-width": {
       "version": "2.2.0",
+      "from": "cli-width@https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "cliui": {
       "version": "2.1.0",
+      "from": "cliui@https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "optional": true,
-      "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3"
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "from": "wordwrap@0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "cls-bluebird": {
       "version": "2.0.1",
+      "from": "cls-bluebird@https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.0.1.tgz",
-      "integrity": "sha1-wlmkgK4CwOUGE0MHuxPbMERu4uc=",
-      "dev": true,
-      "requires": {
-        "is-bluebird": "1.0.2",
-        "shimmer": "1.1.0"
-      }
+      "dev": true
     },
     "cluster-key-slot": {
       "version": "1.0.8",
+      "from": "cluster-key-slot@https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.0.8.tgz",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.0.8.tgz",
-      "integrity": "sha1-dlRVYIWmUzCTKi6LWXb44tCz5BQ=",
       "dev": true
     },
     "cluster-messages": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cluster-messages/-/cluster-messages-1.1.2.tgz",
-      "integrity": "sha1-86dHQQoDOsjHWmnf/hF8lPPec1w=",
-      "dev": true,
-      "requires": {
-        "uuid4": "1.0.0"
-      }
+      "from": "cluster-messages@https://registry.npmjs.org/cluster-messages/-/cluster-messages-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/cluster-messages/-/cluster-messages-1.1.2.tgz"
     },
     "co": {
       "version": "4.6.0",
+      "from": "co@https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
+      "from": "code-point-at@https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "codependency": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/codependency/-/codependency-2.0.1.tgz",
-      "integrity": "sha1-0VOlSpYGKnX95IlYxNyV/z2z0JM=",
-      "requires": {
-        "semver": "5.3.0"
-      }
+      "from": "codependency@https://registry.npmjs.org/codependency/-/codependency-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/codependency/-/codependency-2.0.1.tgz"
     },
     "collect-all": {
       "version": "1.0.3",
+      "from": "collect-all@https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
-      "integrity": "sha1-GrzCBEi1ihRHSH/PNBMOlRKwrPg=",
-      "dev": true,
-      "requires": {
-        "stream-connect": "1.0.2",
-        "stream-via": "1.0.4"
-      }
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.5",
+      "from": "combined-stream@https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
+      "dev": true
     },
     "command-line-args": {
       "version": "5.0.1",
+      "from": "command-line-args@https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.1.tgz",
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.1.tgz",
-      "integrity": "sha1-FhC6GjC1Zggc4/USaMGIjAWFh70=",
-      "dev": true,
-      "requires": {
-        "argv-tools": "0.1.1",
-        "array-back": "2.0.0",
-        "find-replace": "2.0.1",
-        "lodash.camelcase": "4.3.0",
-        "typical": "2.6.1"
-      }
+      "dev": true
     },
     "command-line-tool": {
       "version": "0.8.0",
+      "from": "command-line-tool@https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz",
       "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz",
-      "integrity": "sha1-sAKQ7x38EcxzHdH0OpLPpfIecVs=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "4.0.0",
-        "array-back": "2.0.0",
-        "command-line-args": "5.0.1",
-        "command-line-usage": "4.1.0",
-        "typical": "2.6.1"
-      }
+      "dev": true
     },
     "command-line-usage": {
       "version": "4.1.0",
+      "from": "command-line-usage@https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-      "integrity": "sha1-prOy4nA7Tc+L1GrhnhGKmlKXKII=",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "4.0.0",
-        "array-back": "2.0.0",
-        "table-layout": "0.4.2",
-        "typical": "2.6.1"
-      }
+      "dev": true
     },
     "commander": {
       "version": "2.11.0",
+      "from": "commander@https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
       "dev": true
     },
     "common-sequence": {
       "version": "1.0.2",
+      "from": "common-sequence@https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
-      "integrity": "sha1-MOB/P49vf5s97oVPILLTnu4Ibeg=",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
+      "from": "concat-map@https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
       "version": "1.6.0",
+      "from": "concat-stream@https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.2.7",
-        "typedarray": "0.0.6"
-      }
+      "dev": true
     },
     "config-master": {
       "version": "3.1.0",
+      "from": "config-master@https://registry.npmjs.org/config-master/-/config-master-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/config-master/-/config-master-3.1.0.tgz",
-      "integrity": "sha1-ZnZjWQUFooO/JqSE1oSJ10xUhdo=",
       "dev": true,
-      "requires": {
-        "walk-back": "2.0.1"
-      },
       "dependencies": {
         "walk-back": {
           "version": "2.0.1",
+          "from": "walk-back@https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
-          "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
           "dev": true
         }
       }
     },
     "contains-path": {
       "version": "0.1.0",
+      "from": "contains-path@https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
+      "from": "core-util-is@https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "coveralls": {
       "version": "2.13.1",
+      "from": "coveralls@https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
-      "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
-      "dev": true,
-      "requires": {
-        "js-yaml": "3.6.1",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.5",
-        "minimist": "1.2.0",
-        "request": "2.79.0"
-      }
+      "dev": true
     },
     "cross-env": {
       "version": "3.2.4",
+      "from": "cross-env@https://registry.npmjs.org/cross-env/-/cross-env-3.2.4.tgz",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-3.2.4.tgz",
-      "integrity": "sha1-ngWF8neGTtQhznVvgamA/w1piro=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "5.1.0",
-        "is-windows": "1.0.1"
-      }
+      "dev": true
     },
     "cross-spawn": {
       "version": "5.1.0",
+      "from": "cross-spawn@https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.2.14"
-      }
+      "dev": true
     },
     "cryptiles": {
       "version": "2.0.5",
+      "from": "cryptiles@https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
-      "requires": {
-        "boom": "2.10.1"
-      }
+      "dev": true
     },
     "d": {
       "version": "1.0.0",
+      "from": "d@https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true,
-      "requires": {
-        "es5-ext": "0.10.38"
-      }
+      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
+      "from": "dashdash@https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
+          "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "debug": {
       "version": "2.6.8",
+      "from": "debug@https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true,
-      "requires": {
-        "ms": "2.0.0"
-      }
+      "dev": true
     },
     "debug-log": {
       "version": "1.0.1",
+      "from": "debug-log@https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
     "decamelize": {
       "version": "1.2.0",
+      "from": "decamelize@https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true,
       "optional": true
     },
     "deep-eql": {
       "version": "0.1.3",
+      "from": "deep-eql@https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
-      "requires": {
-        "type-detect": "0.1.1"
-      },
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
+          "from": "type-detect@https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
           "dev": true
         }
       }
     },
     "deep-equal": {
       "version": "1.0.1",
+      "from": "deep-equal@https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
     "deep-extend": {
       "version": "0.5.0",
+      "from": "deep-extend@https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.0.tgz",
-      "integrity": "sha1-bvSgmwX5iw41jW2T1Mo8rsZnKAM=",
       "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
+      "from": "deep-is@https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "define-properties": {
       "version": "1.1.2",
+      "from": "define-properties@https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true,
-      "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
-      }
+      "dev": true
     },
     "deglob": {
       "version": "2.1.0",
+      "from": "deglob@https://registry.npmjs.org/deglob/-/deglob-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.0.tgz",
-      "integrity": "sha1-TUSr4W7zLHebSXK9FBqAMlApoUo=",
-      "dev": true,
-      "requires": {
-        "find-root": "1.1.0",
-        "glob": "7.1.1",
-        "ignore": "3.3.7",
-        "pkg-config": "1.1.1",
-        "run-parallel": "1.1.6",
-        "uniq": "1.0.1"
-      }
+      "dev": true
     },
     "del": {
       "version": "2.2.2",
+      "from": "del@https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
-      }
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
+      "from": "delayed-stream@https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "denque": {
       "version": "1.1.1",
+      "from": "denque@https://registry.npmjs.org/denque/-/denque-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.1.1.tgz",
-      "integrity": "sha1-ECKcK4juwb0V/4LF/eNW5762254=",
       "dev": true
     },
     "depd": {
       "version": "1.1.0",
+      "from": "depd@https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM=",
       "dev": true
     },
     "diff": {
       "version": "3.2.0",
+      "from": "diff@https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
     "dmd": {
       "version": "3.0.10",
+      "from": "dmd@https://registry.npmjs.org/dmd/-/dmd-3.0.10.tgz",
       "resolved": "https://registry.npmjs.org/dmd/-/dmd-3.0.10.tgz",
-      "integrity": "sha1-+nLhFQ4quh/+Nf4tXUt3FszoNEs=",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0",
-        "cache-point": "0.4.1",
-        "common-sequence": "1.0.2",
-        "file-set": "1.1.1",
-        "handlebars": "4.0.11",
-        "marked": "0.3.12",
-        "object-get": "2.1.0",
-        "reduce-flatten": "1.0.1",
-        "reduce-unique": "1.0.0",
-        "reduce-without": "1.0.1",
-        "test-value": "3.0.0",
-        "walk-back": "3.0.0"
-      }
+      "dev": true
     },
     "doctrine": {
       "version": "2.1.0",
+      "from": "doctrine@https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "requires": {
-        "esutils": "2.0.2"
-      }
+      "dev": true
     },
     "dottie": {
       "version": "2.0.0",
+      "from": "dottie@https://registry.npmjs.org/dottie/-/dottie-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.0.tgz",
-      "integrity": "sha1-2hkZgci41xPKARXViYzzl8Lw3dA=",
       "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",
+      "from": "ecc-jsbn@https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
+      "optional": true
     },
     "encoding": {
       "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.18"
-      }
+      "from": "encoding@https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
     },
     "env-cmd": {
       "version": "5.1.0",
+      "from": "env-cmd@https://registry.npmjs.org/env-cmd/-/env-cmd-5.1.0.tgz",
       "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-5.1.0.tgz",
-      "integrity": "sha1-AjbbOTw/AzAFIE/NCpLuQHI6nJ4=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "5.1.0"
-      }
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.1",
+      "from": "error-ex@https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "0.2.1"
-      }
+      "dev": true
     },
     "es-abstract": {
       "version": "1.10.0",
+      "from": "es-abstract@https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
-      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
-      }
+      "dev": true
     },
     "es-to-primitive": {
       "version": "1.1.1",
+      "from": "es-to-primitive@https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true,
-      "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
-      }
+      "dev": true
     },
     "es5-ext": {
       "version": "0.10.38",
+      "from": "es5-ext@https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
-      "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
-      }
+      "dev": true
     },
     "es6-iterator": {
       "version": "2.0.3",
+      "from": "es6-iterator@https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38",
-        "es6-symbol": "3.1.1"
-      }
+      "dev": true
     },
     "es6-map": {
       "version": "0.1.5",
+      "from": "es6-map@https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
-      }
+      "dev": true
     },
     "es6-promise": {
       "version": "3.2.1",
+      "from": "es6-promise@https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
-      "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q=",
       "dev": true
     },
     "es6-set": {
       "version": "0.1.5",
+      "from": "es6-set@https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
-      }
+      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.1",
+      "from": "es6-symbol@https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38"
-      }
+      "dev": true
     },
     "es6-weak-map": {
       "version": "2.0.2",
+      "from": "es6-weak-map@https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
-      }
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
+      "from": "escape-string-regexp@https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "escope": {
       "version": "3.6.0",
+      "from": "escope@https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true,
-      "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
-      }
+      "dev": true
     },
     "eslint": {
       "version": "3.19.0",
+      "from": "eslint@https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
-      "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.0",
-        "debug": "2.6.8",
-        "doctrine": "2.1.0",
-        "escope": "3.6.0",
-        "espree": "3.5.2",
-        "esquery": "1.0.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "glob": "7.1.1",
-        "globals": "9.18.0",
-        "ignore": "3.3.7",
-        "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.6.1",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "shelljs": "0.7.8",
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
-      }
+      "dev": true
     },
     "eslint-config-standard": {
       "version": "10.2.1",
+      "from": "eslint-config-standard@https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
-      "integrity": "sha1-wGHk0GbzedwXzVYsZOgZtN1FRZE=",
       "dev": true
     },
     "eslint-config-standard-jsx": {
       "version": "4.0.2",
+      "from": "eslint-config-standard-jsx@https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz",
       "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz",
-      "integrity": "sha512-F8fRh2WFnTek7dZH9ZaE0PCBwdVGkwVWZmizla/DDNOmg7Tx6B/IlK5+oYpiX29jpu73LszeJj5i1axEZv6VMw==",
       "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.2.3",
+      "from": "eslint-import-resolver-node@https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
-      "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "object-assign": "4.1.1",
-        "resolve": "1.5.0"
-      }
+      "dev": true
     },
     "eslint-module-utils": {
       "version": "2.1.1",
+      "from": "eslint-module-utils@https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.8",
-        "pkg-dir": "1.0.0"
-      }
+      "dev": true
     },
     "eslint-plugin-import": {
       "version": "2.2.0",
+      "from": "eslint-plugin-import@https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
-      "integrity": "sha1-crowb60wXWfEgWNIpGmaQimsi04=",
       "dev": true,
-      "requires": {
-        "builtin-modules": "1.1.1",
-        "contains-path": "0.1.0",
-        "debug": "2.6.8",
-        "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.2.3",
-        "eslint-module-utils": "2.1.1",
-        "has": "1.0.1",
-        "lodash.cond": "4.5.2",
-        "minimatch": "3.0.4",
-        "pkg-up": "1.0.0"
-      },
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
+          "from": "doctrine@https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
     "eslint-plugin-node": {
       "version": "4.2.3",
+      "from": "eslint-plugin-node@https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz",
-      "integrity": "sha512-vIUQPuwbVYdz/CYnlTLsJrRy7iXHQjdEe5wz0XhhdTym3IInM/zZLlPf9nZ2mThsH0QcsieCOWs2vOeCy/22LQ==",
-      "dev": true,
-      "requires": {
-        "ignore": "3.3.7",
-        "minimatch": "3.0.4",
-        "object-assign": "4.1.1",
-        "resolve": "1.5.0",
-        "semver": "5.3.0"
-      }
+      "dev": true
     },
     "eslint-plugin-promise": {
       "version": "3.5.0",
+      "from": "eslint-plugin-promise@https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz",
-      "integrity": "sha1-ePu2/+BHIBYnVp6FpsU3OvKmj8o=",
       "dev": true
     },
     "eslint-plugin-react": {
       "version": "6.10.3",
+      "from": "eslint-plugin-react@https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
-      "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
       "dev": true,
-      "requires": {
-        "array.prototype.find": "2.0.4",
-        "doctrine": "1.5.0",
-        "has": "1.0.1",
-        "jsx-ast-utils": "1.4.1",
-        "object.assign": "4.1.0"
-      },
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
+          "from": "doctrine@https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
     "eslint-plugin-standard": {
       "version": "3.0.1",
+      "from": "eslint-plugin-standard@https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
-      "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
       "dev": true
     },
     "espree": {
       "version": "3.5.2",
+      "from": "espree@https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
-      "dev": true,
-      "requires": {
-        "acorn": "5.3.0",
-        "acorn-jsx": "3.0.1"
-      }
+      "dev": true
     },
     "esprima": {
       "version": "2.7.3",
+      "from": "esprima@https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
       "dev": true
     },
     "esquery": {
       "version": "1.0.0",
+      "from": "esquery@https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true,
-      "requires": {
-        "estraverse": "4.2.0"
-      }
+      "dev": true
     },
     "esrecurse": {
       "version": "4.2.0",
+      "from": "esrecurse@https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-      "dev": true,
-      "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "estraverse": {
       "version": "4.2.0",
+      "from": "estraverse@https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.2",
+      "from": "esutils@https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "event-emitter": {
       "version": "0.3.5",
+      "from": "event-emitter@https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38"
-      }
+      "dev": true
     },
     "exit-hook": {
       "version": "1.1.1",
+      "from": "exit-hook@https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "extend": {
       "version": "3.0.1",
+      "from": "extend@https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
     "extsprintf": {
       "version": "1.0.2",
+      "from": "extsprintf@https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
+      "from": "fast-levenshtein@https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "figures": {
       "version": "1.7.0",
+      "from": "figures@https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "file-entry-cache": {
       "version": "2.0.0",
+      "from": "file-entry-cache@https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true,
-      "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "file-set": {
       "version": "1.1.1",
+      "from": "file-set@https://registry.npmjs.org/file-set/-/file-set-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/file-set/-/file-set-1.1.1.tgz",
-      "integrity": "sha1-0+xwwIDsjxjyBLod4QZ4DJBWkms=",
       "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "glob": "7.1.1"
-      },
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
+          "from": "array-back@https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "dev": true,
-          "requires": {
-            "typical": "2.6.1"
-          }
+          "dev": true
         }
       }
     },
     "find-replace": {
       "version": "2.0.1",
+      "from": "find-replace@https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
-      "integrity": "sha1-bZaDp8og+PmqvqutB+TiWA9ShVA=",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0",
-        "test-value": "3.0.0"
-      }
+      "dev": true
     },
     "find-root": {
       "version": "1.1.0",
+      "from": "find-root@https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "dev": true
     },
     "find-up": {
       "version": "1.1.2",
+      "from": "find-up@https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true,
-      "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "flat-cache": {
       "version": "1.3.0",
+      "from": "flat-cache@https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-      "dev": true,
-      "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
-      }
+      "dev": true
     },
     "flexbuffer": {
       "version": "0.0.6",
+      "from": "flexbuffer@https://registry.npmjs.org/flexbuffer/-/flexbuffer-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/flexbuffer/-/flexbuffer-0.0.6.tgz",
-      "integrity": "sha1-A5/fI/iCPkQMOPMnfm/vEXQhWzA=",
       "dev": true
     },
     "foreach": {
       "version": "2.0.5",
+      "from": "foreach@https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
+      "from": "forever-agent@https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
       "version": "2.1.4",
+      "from": "form-data@https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true,
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.15"
-      }
+      "dev": true
     },
     "formatio": {
       "version": "1.2.0",
+      "from": "formatio@https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-      "dev": true,
-      "requires": {
-        "samsam": "1.2.1"
-      }
+      "dev": true
     },
     "fs-then-native": {
       "version": "2.0.0",
+      "from": "fs-then-native@https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
-      "integrity": "sha1-GaEk2U2QwiyOBF8ujdbr6jbUjGc=",
       "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
+      "from": "fs.realpath@https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
+      "from": "function-bind@https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "generate-function": {
       "version": "2.0.0",
+      "from": "generate-function@https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
       "dev": true
     },
     "generate-object-property": {
       "version": "1.2.0",
+      "from": "generate-object-property@https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "1.0.2"
-      }
+      "dev": true
     },
     "generic-pool": {
       "version": "3.1.7",
+      "from": "generic-pool@https://registry.npmjs.org/generic-pool/-/generic-pool-3.1.7.tgz",
       "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.1.7.tgz",
-      "integrity": "sha1-2sIrLHp6BOQXMvfY0tJaMDyI9mI=",
       "dev": true
     },
     "get-stdin": {
       "version": "5.0.1",
+      "from": "get-stdin@https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
+      "from": "getpass@https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
+          "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "glob": {
       "version": "7.1.1",
+      "from": "glob@https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
+      "dev": true
     },
     "globals": {
       "version": "9.18.0",
+      "from": "globals@https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globby": {
       "version": "5.0.0",
+      "from": "globby@https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.1.11",
+      "from": "graceful-fs@https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
+      "from": "graceful-readlink@https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
     "growl": {
       "version": "1.9.2",
+      "from": "growl@https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
     "handlebars": {
       "version": "4.0.11",
+      "from": "handlebars@https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
-      "requires": {
-        "async": "2.1.4",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "from": "async@>=1.4.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "dev": true
+        }
       }
     },
     "har-validator": {
       "version": "2.0.6",
+      "from": "har-validator@https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "commander": "2.11.0",
-        "is-my-json-valid": "2.16.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "has": {
       "version": "1.0.1",
+      "from": "has@https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true,
-      "requires": {
-        "function-bind": "1.1.1"
-      }
+      "dev": true
     },
     "has-ansi": {
       "version": "2.0.0",
+      "from": "has-ansi@https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "dev": true
     },
     "has-flag": {
       "version": "1.0.0",
+      "from": "has-flag@https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
+      "from": "has-symbols@https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "hawk": {
       "version": "3.1.3",
+      "from": "hawk@https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
-      "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
-      }
+      "dev": true
     },
     "hoek": {
       "version": "2.16.3",
+      "from": "hoek@https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
     "hooks-fixed": {
       "version": "2.0.0",
+      "from": "hooks-fixed@https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.0.tgz",
-      "integrity": "sha1-oB2JTVKsf2WZu7H2PfycQR33DLo=",
       "dev": true
     },
     "http-signature": {
       "version": "1.1.1",
+      "from": "http-signature@https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.0",
-        "sshpk": "1.13.1"
-      }
+      "dev": true
     },
     "human-interval": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/human-interval/-/human-interval-0.1.6.tgz",
-      "integrity": "sha1-AFeXNFR2TDq8vrKu1hL8lkTmhIg="
+      "from": "human-interval@https://registry.npmjs.org/human-interval/-/human-interval-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/human-interval/-/human-interval-0.1.6.tgz"
     },
     "iconv-lite": {
       "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha1-I9hlaxaq5nQqwpcy6o8DNqR4nPI="
+      "from": "iconv-lite@https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
     },
     "ignore": {
       "version": "3.3.7",
+      "from": "ignore@https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
+      "from": "imurmurhash@https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "inflection": {
       "version": "1.10.0",
+      "from": "inflection@https://registry.npmjs.org/inflection/-/inflection-1.10.0.tgz",
       "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.10.0.tgz",
-      "integrity": "sha1-W//LEZetPoEFD44X4hZoCH7p6y8=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
+      "from": "inflight@https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
+      "dev": true
     },
     "inherits": {
       "version": "2.0.3",
+      "from": "inherits@https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "inquirer": {
       "version": "0.12.0",
+      "from": "inquirer@https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.2.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.4",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
-      }
+      "dev": true
     },
     "interpret": {
       "version": "1.1.0",
+      "from": "interpret@https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "ioredis": {
       "version": "3.1.1",
+      "from": "ioredis@https://registry.npmjs.org/ioredis/-/ioredis-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-3.1.1.tgz",
-      "integrity": "sha1-zC8dMjK4yVzBUwRrzhaPK6oRhug=",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.5.0",
-        "cluster-key-slot": "1.0.8",
-        "debug": "2.6.8",
-        "denque": "1.1.1",
-        "flexbuffer": "0.0.6",
-        "lodash": "4.17.4",
-        "redis-commands": "1.3.1",
-        "redis-parser": "2.6.0"
-      }
+      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
+      "from": "is-arrayish@https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-bluebird": {
       "version": "1.0.2",
+      "from": "is-bluebird@https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
-      "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI=",
       "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
+      "from": "is-buffer@https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-callable": {
       "version": "1.1.3",
+      "from": "is-callable@https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
       "dev": true
     },
     "is-date-object": {
       "version": "1.0.1",
+      "from": "is-date-object@https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
+      "from": "is-fullwidth-code-point@https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "dev": true
     },
     "is-my-json-valid": {
       "version": "2.16.0",
+      "from": "is-my-json-valid@https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true,
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
-      }
+      "dev": true
     },
     "is-path-cwd": {
       "version": "1.0.0",
+      "from": "is-path-cwd@https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
+      "from": "is-path-in-cwd@https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "1.0.1"
-      }
+      "dev": true
     },
     "is-path-inside": {
       "version": "1.0.1",
+      "from": "is-path-inside@https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "1.0.2"
-      }
+      "dev": true
     },
     "is-property": {
       "version": "1.0.2",
+      "from": "is-property@https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
+      "from": "is-regex@https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.1"
-      }
+      "dev": true
     },
     "is-resolvable": {
       "version": "1.1.0",
+      "from": "is-resolvable@https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "from": "is-stream@https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
     "is-symbol": {
       "version": "1.0.1",
+      "from": "is-symbol@https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
+      "from": "is-typedarray@https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-windows": {
       "version": "1.0.1",
+      "from": "is-windows@https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
-      "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
       "dev": true
     },
     "isarray": {
       "version": "1.0.0",
+      "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
+      "from": "isexe@https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
+      "from": "isstream@https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
+      "from": "js-tokens@https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
       "version": "3.6.1",
+      "from": "js-yaml@https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-      "dev": true,
-      "requires": {
-        "argparse": "1.0.9",
-        "esprima": "2.7.3"
-      }
+      "dev": true
     },
     "js2xmlparser": {
       "version": "3.0.0",
+      "from": "js2xmlparser@https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
-      "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
-      "dev": true,
-      "requires": {
-        "xmlcreate": "1.0.2"
-      }
+      "dev": true
     },
     "jsbn": {
       "version": "0.1.1",
+      "from": "jsbn@https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
     },
     "jsdoc": {
       "version": "3.5.5",
+      "from": "jsdoc@https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
       "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
-      "integrity": "sha1-SEUhsSboGQTWMv+D7JqqCWcI+k0=",
-      "dev": true,
-      "requires": {
-        "babylon": "7.0.0-beta.19",
-        "bluebird": "3.5.0",
-        "catharsis": "0.8.9",
-        "escape-string-regexp": "1.0.5",
-        "js2xmlparser": "3.0.0",
-        "klaw": "2.0.0",
-        "marked": "0.3.12",
-        "mkdirp": "0.5.1",
-        "requizzle": "0.2.1",
-        "strip-json-comments": "2.0.1",
-        "taffydb": "2.6.2",
-        "underscore": "1.8.3"
-      }
+      "dev": true
     },
     "jsdoc-api": {
       "version": "4.0.1",
+      "from": "jsdoc-api@https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-4.0.1.tgz",
-      "integrity": "sha1-NXyQH5P+ABHgCQ08WWxiIxEOmqk=",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0",
-        "cache-point": "0.4.1",
-        "collect-all": "1.0.3",
-        "file-set": "1.1.1",
-        "fs-then-native": "2.0.0",
-        "jsdoc": "3.5.5",
-        "object-to-spawn-args": "1.1.1",
-        "temp-path": "1.0.0",
-        "walk-back": "3.0.0"
-      }
+      "dev": true
     },
     "jsdoc-parse": {
       "version": "3.0.1",
+      "from": "jsdoc-parse@https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-3.0.1.tgz",
-      "integrity": "sha1-EZTWoWot++X7jMz+tQWOqAh1mJM=",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0",
-        "lodash.omit": "4.5.0",
-        "lodash.pick": "4.4.0",
-        "reduce-extract": "1.0.0",
-        "sort-array": "2.0.0",
-        "test-value": "3.0.0"
-      }
+      "dev": true
     },
     "jsdoc-to-markdown": {
       "version": "4.0.1",
+      "from": "jsdoc-to-markdown@https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-4.0.1.tgz",
-      "integrity": "sha1-JH99l37MIJQoly7JLKFL1OYQNV0=",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0",
-        "command-line-tool": "0.8.0",
-        "config-master": "3.1.0",
-        "dmd": "3.0.10",
-        "jsdoc-api": "4.0.1",
-        "jsdoc-parse": "3.0.1",
-        "walk-back": "3.0.0"
-      }
+      "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.1",
+      "from": "json-parse-better-errors@https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
       "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
+      "from": "json-schema@https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
+      "from": "json-stable-stringify@https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "0.0.0"
-      }
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
+      "from": "json-stringify-safe@https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json3": {
       "version": "3.3.2",
+      "from": "json3@https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
     "jsonify": {
       "version": "0.0.0",
+      "from": "jsonify@https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsonpointer": {
       "version": "4.0.1",
+      "from": "jsonpointer@https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
     "jsprim": {
       "version": "1.4.0",
+      "from": "jsprim@https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-      "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
       "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.0.2",
-        "json-schema": "0.2.3",
-        "verror": "1.3.6"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
+          "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "jsx-ast-utils": {
       "version": "1.4.1",
+      "from": "jsx-ast-utils@https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
-      "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
       "dev": true
     },
     "kareem": {
       "version": "1.4.1",
+      "from": "kareem@https://registry.npmjs.org/kareem/-/kareem-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.4.1.tgz",
-      "integrity": "sha1-7XYgAET6BB7zK02oJh4lU/EXNTE=",
       "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
+      "from": "kind-of@https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "1.1.6"
-      }
+      "dev": true
     },
     "klaw": {
       "version": "2.0.0",
+      "from": "klaw@https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
-      "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
+      "dev": true
     },
     "lazy-cache": {
       "version": "1.0.4",
+      "from": "lazy-cache@https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true,
       "optional": true
     },
     "lcov-parse": {
       "version": "0.0.10",
+      "from": "lcov-parse@https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
     },
     "levn": {
       "version": "0.3.0",
+      "from": "levn@https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
-      }
+      "dev": true
     },
     "load-json-file": {
       "version": "4.0.0",
+      "from": "load-json-file@https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "4.0.0",
-        "pify": "3.0.0",
-        "strip-bom": "3.0.0"
-      },
       "dependencies": {
         "pify": {
           "version": "3.0.0",
+          "from": "pify@https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
       }
     },
     "locate-path": {
       "version": "2.0.0",
+      "from": "locate-path@https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
-      "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
-      },
       "dependencies": {
         "path-exists": {
           "version": "3.0.0",
+          "from": "path-exists@https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
       }
     },
     "lodash": {
       "version": "4.17.4",
+      "from": "lodash@https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
+      "from": "lodash._baseassign@https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      }
+      "dev": true
     },
     "lodash._basecopy": {
       "version": "3.0.1",
+      "from": "lodash._basecopy@https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basecreate": {
       "version": "3.0.3",
+      "from": "lodash._basecreate@https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
       "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
+      "from": "lodash._getnative@https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
+      "from": "lodash._isiterateecall@https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
+      "from": "lodash.camelcase@https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "from": "lodash.clonedeep@https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz"
     },
     "lodash.cond": {
       "version": "4.5.2",
+      "from": "lodash.cond@https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
     "lodash.create": {
       "version": "3.1.1",
+      "from": "lodash.create@https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
-      }
+      "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
+      "from": "lodash.isarguments@https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
+      "from": "lodash.isarray@https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
     "lodash.isobject": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
+      "from": "lodash.isobject@https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz"
     },
     "lodash.keys": {
       "version": "3.1.2",
+      "from": "lodash.keys@https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
+      "dev": true
     },
     "lodash.omit": {
       "version": "4.5.0",
+      "from": "lodash.omit@https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
       "dev": true
     },
     "lodash.padend": {
       "version": "4.6.1",
+      "from": "lodash.padend@https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
       "dev": true
     },
     "lodash.pick": {
       "version": "4.4.0",
+      "from": "lodash.pick@https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
       "dev": true
     },
     "log-driver": {
       "version": "1.2.5",
+      "from": "log-driver@https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
-      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
       "dev": true
     },
     "lolex": {
       "version": "1.6.0",
+      "from": "lolex@https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
       "dev": true
     },
     "longest": {
       "version": "1.0.1",
+      "from": "longest@https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "lru-cache": {
       "version": "4.1.1",
+      "from": "lru-cache@https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
-      "dev": true,
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
+      "dev": true
     },
     "marked": {
       "version": "0.3.12",
+      "from": "marked@https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
-      "integrity": "sha1-fPJf8iUmMvP+JAa94ljpTu6SdRk=",
       "dev": true
     },
     "mime-db": {
       "version": "1.27.0",
+      "from": "mime-db@https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.15",
+      "from": "mime-types@https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-      "dev": true,
-      "requires": {
-        "mime-db": "1.27.0"
-      }
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
+      "from": "minimatch@https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "1.1.8"
-      }
+      "dev": true
     },
     "minimist": {
       "version": "1.2.0",
+      "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
+      "from": "mkdirp@https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
+          "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
       }
     },
     "mkdirp2": {
       "version": "1.0.3",
+      "from": "mkdirp2@https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.3.tgz",
-      "integrity": "sha1-zI3YJl8fBuLY9bELblL04FC+0hs=",
       "dev": true
     },
     "mocha": {
       "version": "3.4.2",
+      "from": "mocha@https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
-      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
       "dev": true,
-      "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.6.0",
-        "diff": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.1",
-        "growl": "1.9.2",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
-      },
       "dependencies": {
         "commander": {
           "version": "2.9.0",
+          "from": "commander@https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
+          "dev": true
         },
         "debug": {
           "version": "2.6.0",
+          "from": "debug@https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-          "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.2",
+          "from": "ms@https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
           "dev": true
         },
         "supports-color": {
           "version": "3.1.2",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
     "moment": {
       "version": "2.18.1",
+      "from": "moment@https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
       "dev": true
     },
     "moment-timezone": {
       "version": "0.5.13",
+      "from": "moment-timezone@https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz",
-      "integrity": "sha1-mc5cfYJyYusPH3AgRBd/YHRde5A=",
-      "dev": true,
-      "requires": {
-        "moment": "2.18.1"
-      }
+      "dev": true
     },
     "mongodb": {
       "version": "2.2.29",
+      "from": "mongodb@https://registry.npmjs.org/mongodb/-/mongodb-2.2.29.tgz",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.29.tgz",
-      "integrity": "sha1-NrJEEm8mdmxevWRluKtbVC1oM8U=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "3.2.1",
-        "mongodb-core": "2.1.13",
-        "readable-stream": "2.2.7"
-      }
+      "dev": true
     },
     "mongodb-core": {
       "version": "2.1.13",
+      "from": "mongodb-core@https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.13.tgz",
       "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.13.tgz",
-      "integrity": "sha1-dx72OCcKyZOrQphGiauCQlG5aog=",
-      "dev": true,
-      "requires": {
-        "bson": "1.0.4",
-        "require_optional": "1.0.1"
-      }
+      "dev": true
     },
     "mongoose": {
       "version": "4.11.1",
+      "from": "mongoose@https://registry.npmjs.org/mongoose/-/mongoose-4.11.1.tgz",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.11.1.tgz",
-      "integrity": "sha1-JWC22J50SwWFfQJMq4sxYGZxbj4=",
       "dev": true,
-      "requires": {
-        "async": "2.1.4",
-        "bson": "1.0.4",
-        "hooks-fixed": "2.0.0",
-        "kareem": "1.4.1",
-        "mongodb": "2.2.27",
-        "mpath": "0.3.0",
-        "mpromise": "0.5.5",
-        "mquery": "2.3.1",
-        "ms": "2.0.0",
-        "muri": "1.2.1",
-        "regexp-clone": "0.0.1",
-        "sliced": "1.0.1"
-      },
       "dependencies": {
         "mongodb": {
           "version": "2.2.27",
+          "from": "mongodb@https://registry.npmjs.org/mongodb/-/mongodb-2.2.27.tgz",
           "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.27.tgz",
-          "integrity": "sha1-NBIgNNtm2YO89qta2yaiSnD+9uY=",
-          "dev": true,
-          "requires": {
-            "es6-promise": "3.2.1",
-            "mongodb-core": "2.1.11",
-            "readable-stream": "2.2.7"
-          }
+          "dev": true
         },
         "mongodb-core": {
           "version": "2.1.11",
+          "from": "mongodb-core@https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.11.tgz",
           "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.11.tgz",
-          "integrity": "sha1-HDh3bOsXSZepnCiGDu2QKNqbPho=",
-          "dev": true,
-          "requires": {
-            "bson": "1.0.4",
-            "require_optional": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
     "mpath": {
       "version": "0.3.0",
+      "from": "mpath@https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz",
-      "integrity": "sha1-elj3iem1/TyUUgY0FXlg8mvV70Q=",
       "dev": true
     },
     "mpromise": {
       "version": "0.5.5",
+      "from": "mpromise@https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
       "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
-      "integrity": "sha1-9bJCWddjrMIlewoMjG2Gb9UXMuY=",
       "dev": true
     },
     "mquery": {
       "version": "2.3.1",
+      "from": "mquery@https://registry.npmjs.org/mquery/-/mquery-2.3.1.tgz",
       "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.3.1.tgz",
-      "integrity": "sha1-mrNnSXFIAP8LtTpoHOS8TV8HyHs=",
       "dev": true,
-      "requires": {
-        "bluebird": "2.10.2",
-        "debug": "2.6.8",
-        "regexp-clone": "0.0.1",
-        "sliced": "0.0.5"
-      },
       "dependencies": {
         "bluebird": {
           "version": "2.10.2",
+          "from": "bluebird@https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
-          "integrity": "sha1-AkpVFylTCIV/FPkfEQb8O1VfRGs=",
           "dev": true
         },
         "sliced": {
           "version": "0.0.5",
+          "from": "sliced@https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
           "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
-          "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8=",
           "dev": true
         }
       }
     },
     "ms": {
       "version": "2.0.0",
+      "from": "ms@https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "muri": {
       "version": "1.2.1",
+      "from": "muri@https://registry.npmjs.org/muri/-/muri-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/muri/-/muri-1.2.1.tgz",
-      "integrity": "sha1-7H6lzmympSPrGrNbrNpfqBbJqjw=",
       "dev": true
     },
     "mute-stream": {
       "version": "0.0.5",
+      "from": "mute-stream@https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
     "native-promise-only": {
       "version": "0.8.1",
+      "from": "native-promise-only@https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
       "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
+      "from": "natural-compare@https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "nock": {
       "version": "9.0.13",
+      "from": "nock@https://registry.npmjs.org/nock/-/nock-9.0.13.tgz",
       "resolved": "https://registry.npmjs.org/nock/-/nock-9.0.13.tgz",
-      "integrity": "sha1-0Lw570PTF5mB4isujqBp+RbFeBo=",
-      "dev": true,
-      "requires": {
-        "chai": "3.5.0",
-        "debug": "2.6.8",
-        "deep-equal": "1.0.1",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "propagate": "0.4.0",
-        "qs": "6.3.2"
-      }
+      "dev": true
     },
     "node-fetch": {
       "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-      "integrity": "sha1-iZyz0KPJL5UsR/G4dvTIrqvUANU=",
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
+      "from": "node-fetch@https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz"
     },
     "node-noop": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-noop/-/node-noop-1.0.0.tgz",
-      "integrity": "sha1-R6Pn2Az/qmRYNkvSLthcqzMHvnk="
+      "from": "node-noop@https://registry.npmjs.org/node-noop/-/node-noop-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-noop/-/node-noop-1.0.0.tgz"
     },
     "number-is-nan": {
       "version": "1.0.1",
+      "from": "number-is-nan@https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "nyc": {
       "version": "11.0.3",
+      "from": "nyc@https://registry.npmjs.org/nyc/-/nyc-11.0.3.tgz",
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.0.3.tgz",
-      "integrity": "sha1-DCi8ZpqFFiFwm/eghQMDS+44ErY=",
       "dev": true,
-      "requires": {
-        "archy": "1.0.0",
-        "arrify": "1.0.1",
-        "caching-transform": "1.0.1",
-        "convert-source-map": "1.5.0",
-        "debug-log": "1.0.1",
-        "default-require-extensions": "1.0.0",
-        "find-cache-dir": "0.1.1",
-        "find-up": "2.1.0",
-        "foreground-child": "1.5.6",
-        "glob": "7.1.2",
-        "istanbul-lib-coverage": "1.1.1",
-        "istanbul-lib-hook": "1.0.7",
-        "istanbul-lib-instrument": "1.7.3",
-        "istanbul-lib-report": "1.1.1",
-        "istanbul-lib-source-maps": "1.2.1",
-        "istanbul-reports": "1.1.1",
-        "md5-hex": "1.3.0",
-        "merge-source-map": "1.0.4",
-        "micromatch": "2.3.11",
-        "mkdirp": "0.5.1",
-        "resolve-from": "2.0.0",
-        "rimraf": "2.6.1",
-        "signal-exit": "3.0.2",
-        "spawn-wrap": "1.3.7",
-        "test-exclude": "4.1.1",
-        "yargs": "8.0.2",
-        "yargs-parser": "5.0.0"
-      },
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
+          "from": "align-text@>=0.1.3 <0.2.0",
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2",
-            "longest": "1.0.1",
-            "repeat-string": "1.6.1"
-          }
+          "dev": true
         },
         "amdefine": {
           "version": "1.0.1",
+          "from": "amdefine@>=0.0.4",
           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
           "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
+          "from": "ansi-regex@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
+          "from": "ansi-styles@>=2.2.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
+          "from": "append-transform@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-          "dev": true,
-          "requires": {
-            "default-require-extensions": "1.0.0"
-          }
+          "dev": true
         },
         "archy": {
           "version": "1.0.0",
+          "from": "archy@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "arr-diff": {
           "version": "2.0.0",
+          "from": "arr-diff@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.0.3"
-          }
+          "dev": true
         },
         "arr-flatten": {
           "version": "1.0.3",
+          "from": "arr-flatten@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
-          "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
           "dev": true
         },
         "array-unique": {
           "version": "0.2.1",
+          "from": "array-unique@>=0.2.1 <0.3.0",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
+          "from": "arrify@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
         "async": {
           "version": "1.5.2",
+          "from": "async@>=1.4.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "babel-code-frame": {
           "version": "6.22.0",
+          "from": "babel-code-frame@>=6.22.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-          "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.1"
-          }
+          "dev": true
         },
         "babel-generator": {
           "version": "6.25.0",
+          "from": "babel-generator@>=6.18.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-          "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
-          "dev": true,
-          "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.23.0",
-            "babel-types": "6.25.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.4",
-            "source-map": "0.5.6",
-            "trim-right": "1.0.1"
-          }
+          "dev": true
         },
         "babel-messages": {
           "version": "6.23.0",
+          "from": "babel-messages@>=6.23.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.23.0"
-          }
+          "dev": true
         },
         "babel-runtime": {
           "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-          "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-          "dev": true,
-          "requires": {
-            "core-js": "2.4.1",
-            "regenerator-runtime": "0.10.5"
-          }
+          "dev": true
         },
         "babel-template": {
           "version": "6.25.0",
+          "from": "babel-template@>=6.16.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-          "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.23.0",
-            "babel-traverse": "6.25.0",
-            "babel-types": "6.25.0",
-            "babylon": "6.17.4",
-            "lodash": "4.17.4"
-          }
+          "dev": true
         },
         "babel-traverse": {
           "version": "6.25.0",
+          "from": "babel-traverse@>=6.18.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-          "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "6.22.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.23.0",
-            "babel-types": "6.25.0",
-            "babylon": "6.17.4",
-            "debug": "2.6.8",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
-          }
+          "dev": true
         },
         "babel-types": {
           "version": "6.25.0",
+          "from": "babel-types@>=6.18.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-          "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.23.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
-          }
+          "dev": true
         },
         "babylon": {
           "version": "6.17.4",
+          "from": "babylon@>=6.17.4 <7.0.0",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-          "integrity": "sha1-Pot0AriNIsNCPhN6FXeIOxX/hpo=",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
+          "from": "balanced-match@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.8",
+          "from": "brace-expansion@>=1.1.7 <2.0.0",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
+          "dev": true
         },
         "braces": {
           "version": "1.8.5",
+          "from": "braces@>=1.8.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
-          }
+          "dev": true
         },
         "builtin-modules": {
           "version": "1.1.1",
+          "from": "builtin-modules@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
           "dev": true
         },
         "caching-transform": {
           "version": "1.0.1",
+          "from": "caching-transform@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
-          "dev": true,
-          "requires": {
-            "md5-hex": "1.3.0",
-            "mkdirp": "0.5.1",
-            "write-file-atomic": "1.3.4"
-          }
+          "dev": true
         },
         "camelcase": {
           "version": "1.2.1",
+          "from": "camelcase@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
+          "from": "center-align@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "0.1.4",
-            "lazy-cache": "1.0.4"
-          }
+          "optional": true
         },
         "chalk": {
           "version": "1.1.3",
+          "from": "chalk@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "dev": true
         },
         "cliui": {
           "version": "2.1.0",
+          "from": "cliui@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          },
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
+              "from": "wordwrap@0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
               "dev": true,
               "optional": true
             }
@@ -2715,1512 +1939,1106 @@
         },
         "code-point-at": {
           "version": "1.1.0",
+          "from": "code-point-at@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "commondir": {
           "version": "1.0.1",
+          "from": "commondir@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
+          "from": "concat-map@0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "convert-source-map": {
           "version": "1.5.0",
+          "from": "convert-source-map@>=1.3.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-          "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
           "dev": true
         },
         "core-js": {
           "version": "2.4.1",
+          "from": "core-js@>=2.4.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-          "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
+          "from": "cross-spawn@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "which": "1.2.14"
-          }
+          "dev": true
         },
         "debug": {
           "version": "2.6.8",
+          "from": "debug@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "dev": true
         },
         "debug-log": {
           "version": "1.0.1",
+          "from": "debug-log@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
+          "from": "decamelize@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
+          "from": "default-require-extensions@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-          "dev": true,
-          "requires": {
-            "strip-bom": "2.0.0"
-          }
+          "dev": true
         },
         "detect-indent": {
           "version": "4.0.0",
+          "from": "detect-indent@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-          "dev": true,
-          "requires": {
-            "repeating": "2.0.1"
-          }
+          "dev": true
         },
         "error-ex": {
           "version": "1.3.1",
+          "from": "error-ex@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-          "dev": true,
-          "requires": {
-            "is-arrayish": "0.2.1"
-          }
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
+          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "esutils": {
           "version": "2.0.2",
+          "from": "esutils@>=2.0.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
           "dev": true
         },
         "execa": {
           "version": "0.5.1",
+          "from": "execa@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
-          "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "4.0.2",
-            "get-stream": "2.3.1",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          }
+          "dev": true
         },
         "expand-brackets": {
           "version": "0.1.5",
+          "from": "expand-brackets@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "0.1.1"
-          }
+          "dev": true
         },
         "expand-range": {
           "version": "1.8.2",
+          "from": "expand-range@>=1.8.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-          "dev": true,
-          "requires": {
-            "fill-range": "2.2.3"
-          }
+          "dev": true
         },
         "extglob": {
           "version": "0.3.2",
+          "from": "extglob@>=0.3.1 <0.4.0",
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
+          "dev": true
         },
         "filename-regex": {
           "version": "2.0.1",
+          "from": "filename-regex@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-          "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
           "dev": true
         },
         "fill-range": {
           "version": "2.2.3",
+          "from": "fill-range@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-          "dev": true,
-          "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
-          }
+          "dev": true
         },
         "find-cache-dir": {
           "version": "0.1.1",
+          "from": "find-cache-dir@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-          "dev": true,
-          "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pkg-dir": "1.0.0"
-          }
+          "dev": true
         },
         "find-up": {
           "version": "2.1.0",
+          "from": "find-up@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
+          "dev": true
         },
         "for-in": {
           "version": "1.0.2",
+          "from": "for-in@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
           "dev": true
         },
         "for-own": {
           "version": "0.1.5",
+          "from": "for-own@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-          "dev": true,
-          "requires": {
-            "for-in": "1.0.2"
-          }
+          "dev": true
         },
         "foreground-child": {
           "version": "1.5.6",
+          "from": "foreground-child@>=1.5.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "4.0.2",
-            "signal-exit": "3.0.2"
-          }
+          "dev": true
         },
         "fs.realpath": {
           "version": "1.0.0",
+          "from": "fs.realpath@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
+          "from": "get-caller-file@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
           "dev": true
         },
         "get-stream": {
           "version": "2.3.1",
+          "from": "get-stream@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         },
         "glob": {
           "version": "7.1.2",
+          "from": "glob@>=7.0.6 <8.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "glob-base": {
           "version": "0.3.0",
+          "from": "glob-base@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-          "dev": true,
-          "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
-          }
+          "dev": true
         },
         "glob-parent": {
           "version": "2.0.0",
+          "from": "glob-parent@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "dev": true,
-          "requires": {
-            "is-glob": "2.0.1"
-          }
+          "dev": true
         },
         "globals": {
           "version": "9.18.0",
+          "from": "globals@>=9.0.0 <10.0.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
           "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
+          "from": "graceful-fs@>=4.1.11 <5.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "handlebars": {
           "version": "4.0.10",
+          "from": "handlebars@>=4.0.3 <5.0.0",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-          "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
           "dev": true,
-          "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.29"
-          },
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
+              "from": "source-map@>=0.4.4 <0.5.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
+              "dev": true
             }
           }
         },
         "has-ansi": {
           "version": "2.0.0",
+          "from": "has-ansi@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+          "dev": true
         },
         "has-flag": {
           "version": "1.0.0",
+          "from": "has-flag@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.4.2",
+          "from": "hosted-git-info@>=2.1.4 <3.0.0",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-          "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
+          "from": "imurmurhash@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
+          "from": "inflight@>=1.0.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
+          "dev": true
         },
         "inherits": {
           "version": "2.0.3",
+          "from": "inherits@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "invariant": {
           "version": "2.2.2",
+          "from": "invariant@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-          "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-          "dev": true,
-          "requires": {
-            "loose-envify": "1.3.1"
-          }
+          "dev": true
         },
         "invert-kv": {
           "version": "1.0.0",
+          "from": "invert-kv@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
           "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
+          "from": "is-arrayish@>=0.2.1 <0.3.0",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.5",
+          "from": "is-buffer@>=1.1.5 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-          "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
+          "from": "is-builtin-module@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-          "dev": true,
-          "requires": {
-            "builtin-modules": "1.1.1"
-          }
+          "dev": true
         },
         "is-dotfile": {
           "version": "1.0.3",
+          "from": "is-dotfile@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-          "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
           "dev": true
         },
         "is-equal-shallow": {
           "version": "0.1.3",
+          "from": "is-equal-shallow@>=0.1.3 <0.2.0",
           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-          "dev": true,
-          "requires": {
-            "is-primitive": "2.0.0"
-          }
+          "dev": true
         },
         "is-extendable": {
           "version": "0.1.1",
+          "from": "is-extendable@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
           "dev": true
         },
         "is-extglob": {
           "version": "1.0.0",
+          "from": "is-extglob@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-finite": {
           "version": "1.0.2",
+          "from": "is-finite@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
+          "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
+          "from": "is-glob@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
+          "dev": true
         },
         "is-number": {
           "version": "2.1.0",
+          "from": "is-number@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
+          "dev": true
         },
         "is-posix-bracket": {
           "version": "0.1.1",
+          "from": "is-posix-bracket@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
           "dev": true
         },
         "is-primitive": {
           "version": "2.0.0",
+          "from": "is-primitive@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
+          "from": "is-stream@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
+          "from": "is-utf8@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
+          "from": "isarray@1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
+          "from": "isexe@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "isobject": {
           "version": "2.1.0",
+          "from": "isobject@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
+          "dev": true
         },
         "istanbul-lib-coverage": {
           "version": "1.1.1",
+          "from": "istanbul-lib-coverage@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-          "integrity": "sha1-c7+5mIhSmUFck9OKPprfeEp3qdo=",
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.0.7",
+          "from": "istanbul-lib-hook@>=1.0.7 <2.0.0",
           "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
-          "integrity": "sha1-3WYH8DB2V4/n1vKmMM8UO0m6zdw=",
-          "dev": true,
-          "requires": {
-            "append-transform": "0.4.0"
-          }
+          "dev": true
         },
         "istanbul-lib-instrument": {
           "version": "1.7.3",
+          "from": "istanbul-lib-instrument@>=1.7.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.3.tgz",
-          "integrity": "sha1-klsjkWPqvdaMxASPUsL6T4mez6c=",
-          "dev": true,
-          "requires": {
-            "babel-generator": "6.25.0",
-            "babel-template": "6.25.0",
-            "babel-traverse": "6.25.0",
-            "babel-types": "6.25.0",
-            "babylon": "6.17.4",
-            "istanbul-lib-coverage": "1.1.1",
-            "semver": "5.3.0"
-          }
+          "dev": true
         },
         "istanbul-lib-report": {
           "version": "1.1.1",
+          "from": "istanbul-lib-report@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-          "integrity": "sha1-8OVfVmVf+jQiIIC3oM1HYOFAX8k=",
           "dev": true,
-          "requires": {
-            "istanbul-lib-coverage": "1.1.1",
-            "mkdirp": "0.5.1",
-            "path-parse": "1.0.5",
-            "supports-color": "3.2.3"
-          },
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
+              "from": "supports-color@>=3.1.2 <4.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-              "dev": true,
-              "requires": {
-                "has-flag": "1.0.0"
-              }
+              "dev": true
             }
           }
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.1",
+          "from": "istanbul-lib-source-maps@>=1.2.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
-          "integrity": "sha1-pv4ay6jOCO68Y45XLilNJnAIqgw=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.8",
-            "istanbul-lib-coverage": "1.1.1",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1",
-            "source-map": "0.5.6"
-          }
+          "dev": true
         },
         "istanbul-reports": {
           "version": "1.1.1",
+          "from": "istanbul-reports@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
-          "integrity": "sha1-BCvlyJ4XW8P4ZSPKqynAFOd/7k4=",
-          "dev": true,
-          "requires": {
-            "handlebars": "4.0.10"
-          }
+          "dev": true
         },
         "js-tokens": {
           "version": "3.0.1",
+          "from": "js-tokens@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-          "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
           "dev": true
         },
         "jsesc": {
           "version": "1.3.0",
+          "from": "jsesc@>=1.3.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
+          "from": "kind-of@>=3.0.2 <4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.5"
-          }
+          "dev": true
         },
         "lazy-cache": {
           "version": "1.0.4",
+          "from": "lazy-cache@>=1.0.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
           "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
+          "from": "lcid@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-          "dev": true,
-          "requires": {
-            "invert-kv": "1.0.0"
-          }
+          "dev": true
         },
         "load-json-file": {
           "version": "1.1.0",
+          "from": "load-json-file@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
+          "dev": true
         },
         "locate-path": {
           "version": "2.0.0",
+          "from": "locate-path@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
-          "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
-          },
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
+              "from": "path-exists@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
               "dev": true
             }
           }
         },
         "lodash": {
           "version": "4.17.4",
+          "from": "lodash@>=4.2.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
         "longest": {
           "version": "1.0.1",
+          "from": "longest@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
           "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
+          "from": "loose-envify@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-          "dev": true,
-          "requires": {
-            "js-tokens": "3.0.1"
-          }
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.1",
+          "from": "lru-cache@>=4.0.1 <5.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
-          "dev": true,
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
+          "dev": true
         },
         "md5-hex": {
           "version": "1.3.0",
+          "from": "md5-hex@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-          "dev": true,
-          "requires": {
-            "md5-o-matic": "0.1.1"
-          }
+          "dev": true
         },
         "md5-o-matic": {
           "version": "0.1.1",
+          "from": "md5-o-matic@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
+          "from": "mem@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "1.1.0"
-          }
+          "dev": true
         },
         "merge-source-map": {
           "version": "1.0.4",
+          "from": "merge-source-map@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-          "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.6"
-          }
+          "dev": true
         },
         "micromatch": {
           "version": "2.3.11",
+          "from": "micromatch@>=2.3.11 <3.0.0",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.3"
-          }
+          "dev": true
         },
         "mimic-fn": {
           "version": "1.1.0",
+          "from": "mimic-fn@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-          "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
+          "from": "minimatch@>=3.0.4 <4.0.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "0.0.8",
+          "from": "minimist@0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
+          "dev": true
         },
         "ms": {
           "version": "2.0.0",
+          "from": "ms@2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.3.8",
+          "from": "normalize-package-data@>=2.3.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-          "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "2.4.2",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.3.0",
-            "validate-npm-package-license": "3.0.1"
-          }
+          "dev": true
         },
         "normalize-path": {
           "version": "2.1.1",
+          "from": "normalize-path@>=2.0.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "1.0.2"
-          }
+          "dev": true
         },
         "npm-run-path": {
           "version": "2.0.2",
+          "from": "npm-run-path@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "2.0.1"
-          }
+          "dev": true
         },
         "number-is-nan": {
           "version": "1.0.1",
+          "from": "number-is-nan@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
+          "from": "object-assign@>=4.1.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "object.omit": {
           "version": "2.0.1",
+          "from": "object.omit@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-          "dev": true,
-          "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
-          }
+          "dev": true
         },
         "once": {
           "version": "1.4.0",
+          "from": "once@>=1.3.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
+          "dev": true
         },
         "optimist": {
           "version": "0.6.1",
+          "from": "optimist@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
-          }
+          "dev": true
         },
         "os-homedir": {
           "version": "1.0.2",
+          "from": "os-homedir@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "2.0.0",
+          "from": "os-locale@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
-          "integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ=",
-          "dev": true,
-          "requires": {
-            "execa": "0.5.1",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
-          }
+          "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
+          "from": "p-finally@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
           "version": "1.1.0",
+          "from": "p-limit@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-          "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
           "dev": true
         },
         "p-locate": {
           "version": "2.0.0",
+          "from": "p-locate@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "1.1.0"
-          }
+          "dev": true
         },
         "parse-glob": {
           "version": "3.0.4",
+          "from": "parse-glob@>=3.0.4 <4.0.0",
           "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-          "dev": true,
-          "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
-          }
+          "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
+          "from": "parse-json@>=2.2.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
+          "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
+          "from": "path-exists@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
+          "from": "path-is-absolute@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
+          "from": "path-key@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
+          "from": "path-parse@>=1.0.5 <2.0.0",
           "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
           "dev": true
         },
         "path-type": {
           "version": "1.1.0",
+          "from": "path-type@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         },
         "pify": {
           "version": "2.3.0",
+          "from": "pify@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
+          "from": "pinkie@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
+          "from": "pinkie-promise@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "requires": {
-            "pinkie": "2.0.4"
-          }
+          "dev": true
         },
         "pkg-dir": {
           "version": "1.0.0",
+          "from": "pkg-dir@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
-          "requires": {
-            "find-up": "1.1.2"
-          },
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
+              "from": "find-up@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-              "dev": true,
-              "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
-              }
+              "dev": true
             }
           }
         },
         "preserve": {
           "version": "0.2.0",
+          "from": "preserve@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
+          "from": "pseudomap@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "randomatic": {
           "version": "1.1.7",
+          "from": "randomatic@>=1.1.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-          "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
           "dev": true,
-          "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
-          },
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
+              "from": "is-number@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
+                  "from": "kind-of@^3.0.2",
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.5"
-                  }
+                  "dev": true
                 }
               }
             },
             "kind-of": {
               "version": "4.0.0",
+              "from": "kind-of@>=4.0.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.5"
-              }
+              "dev": true
             }
           }
         },
         "read-pkg": {
           "version": "1.1.0",
+          "from": "read-pkg@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.3.8",
-            "path-type": "1.1.0"
-          }
+          "dev": true
         },
         "read-pkg-up": {
           "version": "1.0.1",
+          "from": "read-pkg-up@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          },
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
+              "from": "find-up@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-              "dev": true,
-              "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
-              }
+              "dev": true
             }
           }
         },
         "regenerator-runtime": {
           "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
           "dev": true
         },
         "regex-cache": {
           "version": "0.4.3",
+          "from": "regex-cache@>=0.4.2 <0.5.0",
           "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-          "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-          "dev": true,
-          "requires": {
-            "is-equal-shallow": "0.1.3",
-            "is-primitive": "2.0.0"
-          }
+          "dev": true
         },
         "remove-trailing-separator": {
           "version": "1.0.2",
+          "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-          "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
           "dev": true
         },
         "repeat-element": {
           "version": "1.1.2",
+          "from": "repeat-element@>=1.1.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
           "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
+          "from": "repeat-string@>=1.5.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
           "dev": true
         },
         "repeating": {
           "version": "2.0.1",
+          "from": "repeating@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
+          "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
+          "from": "require-directory@>=2.1.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
+          "from": "require-main-filename@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
+          "from": "resolve-from@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
+          "from": "right-align@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "0.1.4"
-          }
+          "optional": true
         },
         "rimraf": {
           "version": "2.6.1",
+          "from": "rimraf@>=2.5.4 <3.0.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
+          "dev": true
         },
         "semver": {
           "version": "5.3.0",
+          "from": "semver@>=5.3.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
+          "from": "set-blocking@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
+          "from": "signal-exit@>=3.0.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
+          "from": "slide@>=1.1.5 <2.0.0",
           "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.6",
+          "from": "source-map@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.3.7",
+          "from": "spawn-wrap@>=1.3.7 <2.0.0",
           "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.7.tgz",
-          "integrity": "sha1-vri/RCbWSysGhx4Nfe4mQ/H40bw=",
-          "dev": true,
-          "requires": {
-            "foreground-child": "1.5.6",
-            "mkdirp": "0.5.1",
-            "os-homedir": "1.0.2",
-            "rimraf": "2.6.1",
-            "signal-exit": "3.0.2",
-            "which": "1.2.14"
-          }
+          "dev": true
         },
         "spdx-correct": {
           "version": "1.0.2",
+          "from": "spdx-correct@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-          "dev": true,
-          "requires": {
-            "spdx-license-ids": "1.2.2"
-          }
+          "dev": true
         },
         "spdx-expression-parse": {
           "version": "1.0.4",
+          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
           "dev": true
         },
         "spdx-license-ids": {
           "version": "1.2.2",
+          "from": "spdx-license-ids@>=1.0.2 <2.0.0",
           "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
           "dev": true
         },
         "string-width": {
           "version": "2.0.0",
+          "from": "string-width@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
           "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "3.0.1"
-          },
           "dependencies": {
             "is-fullwidth-code-point": {
               "version": "2.0.0",
+              "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             }
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "from": "strip-ansi@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+          "dev": true
         },
         "strip-bom": {
           "version": "2.0.0",
+          "from": "strip-bom@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
+          "dev": true
         },
         "strip-eof": {
           "version": "1.0.0",
+          "from": "strip-eof@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "test-exclude": {
           "version": "4.1.1",
+          "from": "test-exclude@>=4.1.1 <5.0.0",
           "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-          "integrity": "sha1-TYSWSwlmsAh+zDNKLOAC09k0HiY=",
-          "dev": true,
-          "requires": {
-            "arrify": "1.0.1",
-            "micromatch": "2.3.11",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "require-main-filename": "1.0.1"
-          }
+          "dev": true
         },
         "to-fast-properties": {
           "version": "1.0.3",
+          "from": "to-fast-properties@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
         },
         "trim-right": {
           "version": "1.0.1",
+          "from": "trim-right@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
           "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
+          "from": "uglify-js@>=2.6.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "optional": true,
-          "requires": {
-            "source-map": "0.5.6",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
+              "from": "yargs@>=3.10.0 <3.11.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "dev": true,
-              "optional": true,
-              "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
-                "window-size": "0.1.0"
-              }
+              "optional": true
             }
           }
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
+          "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
           "dev": true,
           "optional": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
+          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-          "dev": true,
-          "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
-          }
+          "dev": true
         },
         "which": {
           "version": "1.2.14",
+          "from": "which@>=1.2.9 <2.0.0",
           "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-          "dev": true,
-          "requires": {
-            "isexe": "2.0.0"
-          }
+          "dev": true
         },
         "which-module": {
           "version": "2.0.0",
+          "from": "which-module@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
+          "from": "window-size@0.1.0",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
+          "from": "wordwrap@>=0.0.2 <0.1.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
+          "from": "wrap-ansi@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
-          },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
+              "from": "string-width@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
+              "dev": true
             }
           }
         },
         "wrappy": {
           "version": "1.0.2",
+          "from": "wrappy@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
+          "from": "write-file-atomic@>=1.1.4 <2.0.0",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
-          }
+          "dev": true
         },
         "y18n": {
           "version": "3.2.1",
+          "from": "y18n@>=3.2.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
+          "from": "yallist@>=2.1.2 <3.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
           "version": "8.0.2",
+          "from": "yargs@>=8.0.1 <9.0.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true,
-          "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.0.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.0.0",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
-          },
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
+              "from": "camelcase@>=4.1.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             },
             "cliui": {
               "version": "3.2.0",
+              "from": "cliui@>=3.2.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
               "dev": true,
-              "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
-              },
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
+                  "from": "string-width@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "dev": true,
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  }
+                  "dev": true
                 }
               }
             },
             "load-json-file": {
               "version": "2.0.0",
+              "from": "load-json-file@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-              "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "strip-bom": "3.0.0"
-              }
+              "dev": true
             },
             "path-type": {
               "version": "2.0.0",
+              "from": "path-type@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-              "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-              "dev": true,
-              "requires": {
-                "pify": "2.3.0"
-              }
+              "dev": true
             },
             "read-pkg": {
               "version": "2.0.0",
+              "from": "read-pkg@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-              "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-              "dev": true,
-              "requires": {
-                "load-json-file": "2.0.0",
-                "normalize-package-data": "2.3.8",
-                "path-type": "2.0.0"
-              }
+              "dev": true
             },
             "read-pkg-up": {
               "version": "2.0.0",
+              "from": "read-pkg-up@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-              "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-              "dev": true,
-              "requires": {
-                "find-up": "2.1.0",
-                "read-pkg": "2.0.0"
-              }
+              "dev": true
             },
             "strip-bom": {
               "version": "3.0.0",
+              "from": "strip-bom@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
               "dev": true
             },
             "yargs-parser": {
               "version": "7.0.0",
+              "from": "yargs-parser@>=7.0.0 <8.0.0",
               "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-              "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-              "dev": true,
-              "requires": {
-                "camelcase": "4.1.0"
-              }
+              "dev": true
             }
           }
         },
         "yargs-parser": {
           "version": "5.0.0",
+          "from": "yargs-parser@>=5.0.0 <6.0.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true,
-          "requires": {
-            "camelcase": "3.0.0"
-          },
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
+              "from": "camelcase@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
               "dev": true
             }
           }
@@ -4229,1050 +3047,777 @@
     },
     "oauth-sign": {
       "version": "0.8.2",
+      "from": "oauth-sign@https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
+      "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-get": {
       "version": "2.1.0",
+      "from": "object-get@https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.0.tgz",
-      "integrity": "sha1-ciu9tgA576R8rTxtws5RqFwCxa4=",
       "dev": true
     },
     "object-keys": {
       "version": "1.0.11",
+      "from": "object-keys@https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
     },
     "object-to-spawn-args": {
       "version": "1.1.1",
+      "from": "object-to-spawn-args@https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
-      "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=",
       "dev": true
     },
     "object.assign": {
       "version": "4.1.0",
+      "from": "object.assign@https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.0",
-        "object-keys": "1.0.11"
-      }
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
+      "from": "once@https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1.0.2"
-      }
+      "dev": true
     },
     "onetime": {
       "version": "1.1.0",
+      "from": "onetime@https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
     "optimist": {
       "version": "0.6.1",
+      "from": "optimist@https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
-      "requires": {
-        "minimist": "1.2.0"
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "from": "minimist@>=0.0.1 <0.1.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "from": "wordwrap@>=0.0.2 <0.1.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "dev": true
+        }
       }
     },
     "optionator": {
       "version": "0.8.2",
+      "from": "optionator@https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
-      "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      }
+      "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",
+      "from": "os-homedir@https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "p-limit": {
       "version": "1.2.0",
+      "from": "p-limit@https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-      "dev": true,
-      "requires": {
-        "p-try": "1.0.0"
-      }
+      "dev": true
     },
     "p-locate": {
       "version": "2.0.0",
+      "from": "p-locate@https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
-      "requires": {
-        "p-limit": "1.2.0"
-      }
+      "dev": true
     },
     "p-try": {
       "version": "1.0.0",
+      "from": "p-try@https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
     "parse-json": {
       "version": "4.0.0",
+      "from": "parse-json@https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-      "dev": true,
-      "requires": {
-        "error-ex": "1.3.1",
-        "json-parse-better-errors": "1.0.1"
-      }
+      "dev": true
     },
     "path-exists": {
       "version": "2.1.0",
+      "from": "path-exists@https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
+      "from": "path-is-absolute@https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
+      "from": "path-is-inside@https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
+      "from": "path-parse@https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "path-to-regexp": {
       "version": "1.7.0",
+      "from": "path-to-regexp@https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
       "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         }
       }
     },
     "pify": {
       "version": "2.3.0",
+      "from": "pify@https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
+      "from": "pinkie@https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
+      "from": "pinkie-promise@https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "2.0.4"
-      }
+      "dev": true
     },
     "pkg-conf": {
       "version": "2.1.0",
+      "from": "pkg-conf@https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
-      "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
       "dev": true,
-      "requires": {
-        "find-up": "2.1.0",
-        "load-json-file": "4.0.0"
-      },
       "dependencies": {
         "find-up": {
           "version": "2.1.0",
+          "from": "find-up@https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
     "pkg-config": {
       "version": "1.1.1",
+      "from": "pkg-config@https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
-      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
-      "dev": true,
-      "requires": {
-        "debug-log": "1.0.1",
-        "find-root": "1.1.0",
-        "xtend": "4.0.1"
-      }
+      "dev": true
     },
     "pkg-dir": {
       "version": "1.0.0",
+      "from": "pkg-dir@https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-      "dev": true,
-      "requires": {
-        "find-up": "1.1.2"
-      }
+      "dev": true
     },
     "pkg-up": {
       "version": "1.0.0",
+      "from": "pkg-up@https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
-      "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
-      "dev": true,
-      "requires": {
-        "find-up": "1.1.2"
-      }
+      "dev": true
     },
     "pluralize": {
       "version": "1.2.1",
+      "from": "pluralize@https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
     },
     "precond": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
+      "from": "precond@https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
     },
     "prelude-ls": {
       "version": "1.1.2",
+      "from": "prelude-ls@https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "1.0.7",
+      "from": "process-nextick-args@https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
     },
     "progress": {
       "version": "1.1.8",
+      "from": "progress@https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
     "propagate": {
       "version": "0.4.0",
+      "from": "propagate@https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
-      "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE=",
       "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
+      "from": "pseudomap@https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "punycode": {
       "version": "1.4.1",
+      "from": "punycode@https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
     "qs": {
       "version": "6.3.2",
+      "from": "qs@https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
       "dev": true
     },
     "readable-stream": {
       "version": "2.2.7",
+      "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
-      "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
-      "dev": true,
-      "requires": {
-        "buffer-shims": "1.0.0",
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
-      }
+      "dev": true
     },
     "readline2": {
       "version": "1.0.1",
+      "from": "readline2@https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "mute-stream": "0.0.5"
-      }
+      "dev": true
     },
     "rechoir": {
       "version": "0.6.2",
+      "from": "rechoir@https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "1.5.0"
-      }
+      "dev": true
     },
     "redis-commands": {
       "version": "1.3.1",
+      "from": "redis-commands@https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
-      "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs=",
       "dev": true
     },
     "redis-parser": {
       "version": "2.6.0",
+      "from": "redis-parser@https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
-      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=",
       "dev": true
     },
     "reduce-extract": {
       "version": "1.0.0",
+      "from": "reduce-extract@https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
-      "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
       "dev": true,
-      "requires": {
-        "test-value": "1.1.0"
-      },
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
+          "from": "array-back@https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "dev": true,
-          "requires": {
-            "typical": "2.6.1"
-          }
+          "dev": true
         },
         "test-value": {
           "version": "1.1.0",
+          "from": "test-value@https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "typical": "2.6.1"
-          }
+          "dev": true
         }
       }
     },
     "reduce-flatten": {
       "version": "1.0.1",
+      "from": "reduce-flatten@https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
       "dev": true
     },
     "reduce-unique": {
       "version": "1.0.0",
+      "from": "reduce-unique@https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz",
-      "integrity": "sha1-flhrz4ek4ytter2Cd/rWzeyfSAM=",
       "dev": true
     },
     "reduce-without": {
       "version": "1.0.1",
+      "from": "reduce-without@https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
-      "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
       "dev": true,
-      "requires": {
-        "test-value": "2.1.0"
-      },
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
+          "from": "array-back@https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "dev": true,
-          "requires": {
-            "typical": "2.6.1"
-          }
+          "dev": true
         },
         "test-value": {
           "version": "2.1.0",
+          "from": "test-value@https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-          "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
-          "dev": true,
-          "requires": {
-            "array-back": "1.0.4",
-            "typical": "2.6.1"
-          }
+          "dev": true
         }
       }
     },
     "regexp-clone": {
       "version": "0.0.1",
+      "from": "regexp-clone@https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
-      "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
+      "from": "repeat-string@https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "request": {
       "version": "2.79.0",
+      "from": "request@https://registry.npmjs.org/request/-/request-2.79.0.tgz",
       "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "0.11.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "2.0.6",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.15",
-        "oauth-sign": "0.8.2",
-        "qs": "6.3.2",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.4.3",
-        "uuid": "3.1.0"
-      }
+      "dev": true
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "from": "require_optional@https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
+      "from": "require-uncached@https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
-      "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
-      },
       "dependencies": {
         "resolve-from": {
           "version": "1.0.1",
+          "from": "resolve-from@https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
           "dev": true
         }
       }
     },
-    "require_optional": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha1-TPNaQkf2TKPfjC7yCMxJSxyo/C4=",
-      "dev": true,
-      "requires": {
-        "resolve-from": "2.0.0",
-        "semver": "5.3.0"
-      }
-    },
     "requizzle": {
       "version": "0.2.1",
+      "from": "requizzle@https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
-      "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
       "dev": true,
-      "requires": {
-        "underscore": "1.6.0"
-      },
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
+          "from": "underscore@https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
           "dev": true
         }
       }
     },
     "resolve": {
       "version": "1.5.0",
+      "from": "resolve@https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-      "dev": true,
-      "requires": {
-        "path-parse": "1.0.5"
-      }
+      "dev": true
     },
     "resolve-from": {
       "version": "2.0.0",
+      "from": "resolve-from@https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
       "dev": true
     },
     "restore-cursor": {
       "version": "1.0.1",
+      "from": "restore-cursor@https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true,
-      "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
-      }
+      "dev": true
     },
     "retry-as-promised": {
       "version": "2.2.0",
+      "from": "retry-as-promised@https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.2.0.tgz",
-      "integrity": "sha1-sEY9f9PPWy/tZFAKtui4pJxbjmw=",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.5.0",
-        "cross-env": "3.2.4",
-        "debug": "2.6.8"
-      }
+      "dev": true
     },
     "right-align": {
       "version": "0.1.3",
+      "from": "right-align@https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "0.1.4"
-      }
+      "optional": true
     },
     "rimraf": {
       "version": "2.6.2",
+      "from": "rimraf@https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.1"
-      }
+      "dev": true
     },
     "run-async": {
       "version": "0.1.0",
+      "from": "run-async@https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0"
-      }
+      "dev": true
     },
     "run-parallel": {
       "version": "1.1.6",
+      "from": "run-parallel@https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
-      "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk=",
       "dev": true
     },
     "rx-lite": {
       "version": "3.1.2",
+      "from": "rx-lite@https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
       "dev": true
     },
     "safe-buffer": {
       "version": "5.1.1",
+      "from": "safe-buffer@https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
       "dev": true
     },
     "samsam": {
       "version": "1.2.1",
+      "from": "samsam@https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
-      "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
       "dev": true
     },
     "semver": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+      "from": "semver@https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
     },
     "sequelize": {
       "version": "4.2.1",
+      "from": "sequelize@https://registry.npmjs.org/sequelize/-/sequelize-4.2.1.tgz",
       "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-4.2.1.tgz",
-      "integrity": "sha1-F/4cWwWDZO/6mrRiTWu3AU9HIkE=",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.5.0",
-        "cls-bluebird": "2.0.1",
-        "debug": "2.6.8",
-        "depd": "1.1.0",
-        "dottie": "2.0.0",
-        "env-cmd": "5.1.0",
-        "generic-pool": "3.1.7",
-        "inflection": "1.10.0",
-        "lodash": "4.17.4",
-        "moment": "2.18.1",
-        "moment-timezone": "0.5.13",
-        "retry-as-promised": "2.2.0",
-        "semver": "5.3.0",
-        "terraformer-wkt-parser": "1.1.2",
-        "toposort-class": "1.0.1",
-        "uuid": "3.1.0",
-        "validator": "6.3.0",
-        "wkx": "0.4.1"
-      }
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
+      "from": "shebang-command@https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "1.0.0"
-      }
+      "dev": true
     },
     "shebang-regex": {
       "version": "1.0.0",
+      "from": "shebang-regex@https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "shelljs": {
       "version": "0.7.8",
+      "from": "shelljs@https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.1",
-        "interpret": "1.1.0",
-        "rechoir": "0.6.2"
-      }
+      "dev": true
     },
     "shimmer": {
       "version": "1.1.0",
+      "from": "shimmer@https://registry.npmjs.org/shimmer/-/shimmer-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.1.0.tgz",
-      "integrity": "sha1-l9c3cTf/u6tCVSLkKf4KqJpIizU=",
       "dev": true
     },
     "sinon": {
       "version": "2.3.6",
+      "from": "sinon@https://registry.npmjs.org/sinon/-/sinon-2.3.6.tgz",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.6.tgz",
-      "integrity": "sha1-lTeOfg+XapcS6bRZH/WznnPcPd4=",
       "dev": true,
-      "requires": {
-        "diff": "3.2.0",
-        "formatio": "1.2.0",
-        "lolex": "1.6.0",
-        "native-promise-only": "0.8.1",
-        "path-to-regexp": "1.7.0",
-        "samsam": "1.2.1",
-        "text-encoding": "0.6.4",
-        "type-detect": "4.0.3"
-      },
       "dependencies": {
         "type-detect": {
           "version": "4.0.3",
+          "from": "type-detect@https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
-          "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
           "dev": true
         }
       }
     },
     "slice-ansi": {
       "version": "0.0.4",
+      "from": "slice-ansi@https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
     "sliced": {
       "version": "1.0.1",
+      "from": "sliced@https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=",
       "dev": true
     },
     "sntp": {
       "version": "1.0.9",
+      "from": "sntp@https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
+      "dev": true
     },
     "sort-array": {
       "version": "2.0.0",
+      "from": "sort-array@https://registry.npmjs.org/sort-array/-/sort-array-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-2.0.0.tgz",
-      "integrity": "sha1-OKnG2if9fRR7QuYFVPKBGHtN9HI=",
       "dev": true,
-      "requires": {
-        "array-back": "1.0.4",
-        "object-get": "2.1.0",
-        "typical": "2.6.1"
-      },
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
+          "from": "array-back@https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "dev": true,
-          "requires": {
-            "typical": "2.6.1"
-          }
+          "dev": true
         }
       }
     },
     "source-map": {
       "version": "0.4.4",
+      "from": "source-map@https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-      "dev": true,
-      "requires": {
-        "amdefine": "1.0.1"
-      }
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
+      "from": "sprintf-js@https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
       "version": "1.13.1",
+      "from": "sshpk@https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
+          "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
       }
     },
     "standard": {
       "version": "10.0.3",
+      "from": "standard@https://registry.npmjs.org/standard/-/standard-10.0.3.tgz",
       "resolved": "https://registry.npmjs.org/standard/-/standard-10.0.3.tgz",
-      "integrity": "sha512-JURZ+85ExKLQULckDFijdX5WHzN6RC7fgiZNSV4jFQVo+3tPoQGHyBrGekye/yf0aOfb4210EM5qPNlc2cRh4w==",
-      "dev": true,
-      "requires": {
-        "eslint": "3.19.0",
-        "eslint-config-standard": "10.2.1",
-        "eslint-config-standard-jsx": "4.0.2",
-        "eslint-plugin-import": "2.2.0",
-        "eslint-plugin-node": "4.2.3",
-        "eslint-plugin-promise": "3.5.0",
-        "eslint-plugin-react": "6.10.3",
-        "eslint-plugin-standard": "3.0.1",
-        "standard-engine": "7.0.0"
-      }
+      "dev": true
     },
     "standard-engine": {
       "version": "7.0.0",
+      "from": "standard-engine@https://registry.npmjs.org/standard-engine/-/standard-engine-7.0.0.tgz",
       "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-7.0.0.tgz",
-      "integrity": "sha1-67d7nI/CyBZf+jU72Rug3/Qa9pA=",
-      "dev": true,
-      "requires": {
-        "deglob": "2.1.0",
-        "get-stdin": "5.0.1",
-        "minimist": "1.2.0",
-        "pkg-conf": "2.1.0"
-      }
+      "dev": true
     },
     "stream-connect": {
       "version": "1.0.2",
+      "from": "stream-connect@https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-      "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
       "dev": true,
-      "requires": {
-        "array-back": "1.0.4"
-      },
       "dependencies": {
         "array-back": {
           "version": "1.0.4",
+          "from": "array-back@https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-          "dev": true,
-          "requires": {
-            "typical": "2.6.1"
-          }
+          "dev": true
         }
       }
     },
     "stream-via": {
       "version": "1.0.4",
+      "from": "stream-via@https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
-      "integrity": "sha1-jcy7CskJMo64vI4qS9OTSv2vYGw=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "from": "string_decoder@https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "dev": true
     },
     "string-width": {
       "version": "1.0.2",
+      "from": "string-width@https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
+      "dev": true
     },
     "stringstream": {
       "version": "0.0.5",
+      "from": "stringstream@https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
       "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
+      "from": "strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "dev": true
     },
     "strip-bom": {
       "version": "3.0.0",
+      "from": "strip-bom@https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
+      "from": "strip-json-comments@https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
+      "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
     "table": {
       "version": "3.8.3",
+      "from": "table@https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
-      "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.17.4",
-        "slice-ansi": "0.0.4",
-        "string-width": "2.1.1"
-      },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
+          "from": "ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
+          "from": "is-fullwidth-code-point@https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
+          "from": "string-width@https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
+          "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
+          "from": "strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
+          "dev": true
         }
       }
     },
     "table-layout": {
       "version": "0.4.2",
+      "from": "table-layout@https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
-      "integrity": "sha1-EOkEPBQqHi0VXaclfkePDvSYF4Y=",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0",
-        "deep-extend": "0.5.0",
-        "lodash.padend": "4.6.1",
-        "typical": "2.6.1",
-        "wordwrapjs": "3.0.0"
-      }
+      "dev": true
     },
     "taffydb": {
       "version": "2.6.2",
+      "from": "taffydb@https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
     },
     "temp-path": {
       "version": "1.0.0",
+      "from": "temp-path@https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
-      "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=",
       "dev": true
     },
     "terraformer": {
       "version": "1.0.8",
+      "from": "terraformer@https://registry.npmjs.org/terraformer/-/terraformer-1.0.8.tgz",
       "resolved": "https://registry.npmjs.org/terraformer/-/terraformer-1.0.8.tgz",
-      "integrity": "sha1-UeCtiXRvzyFh3G9lqnDkI3fItZM=",
-      "dev": true,
-      "requires": {
-        "@types/geojson": "1.0.2"
-      }
+      "dev": true
     },
     "terraformer-wkt-parser": {
       "version": "1.1.2",
+      "from": "terraformer-wkt-parser@https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/terraformer-wkt-parser/-/terraformer-wkt-parser-1.1.2.tgz",
-      "integrity": "sha1-M2oMj8gglKWv+DKI9prt7NNpvww=",
-      "dev": true,
-      "requires": {
-        "terraformer": "1.0.8"
-      }
+      "dev": true
     },
     "test-value": {
       "version": "3.0.0",
+      "from": "test-value@https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
-      "integrity": "sha1-kWjAYvqxGoa41ETdlou0tzhRzpI=",
-      "dev": true,
-      "requires": {
-        "array-back": "2.0.0",
-        "typical": "2.6.1"
-      }
+      "dev": true
     },
     "text-encoding": {
       "version": "0.6.4",
+      "from": "text-encoding@https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
     "text-table": {
       "version": "0.2.0",
+      "from": "text-table@https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
+      "from": "through@https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "toposort-class": {
       "version": "1.0.1",
+      "from": "toposort-class@https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
-      "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg=",
       "dev": true
     },
     "tough-cookie": {
       "version": "2.3.2",
+      "from": "tough-cookie@https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true,
-      "requires": {
-        "punycode": "1.4.1"
-      }
+      "dev": true
     },
     "tunnel-agent": {
       "version": "0.4.3",
+      "from": "tunnel-agent@https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
       "dev": true
     },
     "tweetnacl": {
       "version": "0.14.5",
+      "from": "tweetnacl@https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
     },
     "type-check": {
       "version": "0.3.2",
+      "from": "type-check@https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
+      "dev": true
     },
     "type-detect": {
       "version": "1.0.0",
+      "from": "type-detect@https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
       "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
+      "from": "typedarray@https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "typical": {
       "version": "2.6.1",
+      "from": "typical@https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
       "dev": true
     },
     "uglify-js": {
       "version": "2.8.29",
+      "from": "uglify-js@https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
-      "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
-      },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
+          "from": "source-map@https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true,
           "optional": true
         }
@@ -5280,174 +3825,145 @@
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
+      "from": "uglify-to-browserify@https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
     },
     "underscore": {
       "version": "1.8.3",
+      "from": "underscore@https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
       "dev": true
     },
     "underscore-contrib": {
       "version": "0.3.0",
+      "from": "underscore-contrib@https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
-      "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
       "dev": true,
-      "requires": {
-        "underscore": "1.6.0"
-      },
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
+          "from": "underscore@https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
           "dev": true
         }
       }
     },
     "uniq": {
       "version": "1.0.1",
+      "from": "uniq@https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
     "user-home": {
       "version": "2.0.0",
+      "from": "user-home@https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
+      "from": "util-deprecate@https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "uuid": {
       "version": "3.1.0",
+      "from": "uuid@https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
       "dev": true
     },
     "uuid4": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/uuid4/-/uuid4-1.0.0.tgz",
-      "integrity": "sha1-gTqurxHqL2iQnFrVfYlPgyAtZyA=",
-      "dev": true
+      "from": "uuid4@https://registry.npmjs.org/uuid4/-/uuid4-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/uuid4/-/uuid4-1.0.0.tgz"
     },
     "validator": {
       "version": "6.3.0",
+      "from": "validator@https://registry.npmjs.org/validator/-/validator-6.3.0.tgz",
       "resolved": "https://registry.npmjs.org/validator/-/validator-6.3.0.tgz",
-      "integrity": "sha1-R84j7Y1Ord+p1LjvAHG2zxB418g=",
       "dev": true
     },
     "verror": {
       "version": "1.3.6",
+      "from": "verror@https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true,
-      "requires": {
-        "extsprintf": "1.0.2"
-      }
+      "dev": true
     },
     "walk-back": {
       "version": "3.0.0",
+      "from": "walk-back@https://registry.npmjs.org/walk-back/-/walk-back-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-3.0.0.tgz",
-      "integrity": "sha1-I1h4ejXakQMtrV6S+AsSNw2HlcU=",
       "dev": true
     },
     "which": {
       "version": "1.2.14",
+      "from": "which@https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true,
-      "requires": {
-        "isexe": "2.0.0"
-      }
+      "dev": true
     },
     "window-size": {
       "version": "0.1.0",
+      "from": "window-size@https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true,
       "optional": true
     },
     "wkx": {
       "version": "0.4.1",
+      "from": "wkx@https://registry.npmjs.org/wkx/-/wkx-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.1.tgz",
-      "integrity": "sha1-L8FxtenLVcYlb+9L3h8hvkE77+4=",
-      "dev": true,
-      "requires": {
-        "@types/node": "6.0.79"
-      }
+      "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",
+      "from": "wordwrap@https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wordwrapjs": {
       "version": "3.0.0",
+      "from": "wordwrapjs@https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-      "integrity": "sha1-yUw3KJTK3G/rGma/9k4dmvksXR4=",
-      "dev": true,
-      "requires": {
-        "reduce-flatten": "1.0.1",
-        "typical": "2.6.1"
-      }
+      "dev": true
     },
     "wrappy": {
       "version": "1.0.2",
+      "from": "wrappy@https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write": {
       "version": "0.2.1",
+      "from": "write@https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1"
-      }
+      "dev": true
     },
     "xmlcreate": {
       "version": "1.0.2",
+      "from": "xmlcreate@https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
-      "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
       "dev": true
     },
     "xtend": {
       "version": "4.0.1",
+      "from": "xtend@https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
     "yallist": {
       "version": "2.1.2",
+      "from": "yallist@https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {
       "version": "3.10.0",
+      "from": "yargs@https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
-        "window-size": "0.1.0"
-      }
+      "optional": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   "devDependencies": {
     "@types/node": "^6.0.78",
     "chai": "^3.5.0",
-    "cluster-messages": "1.1.2",
     "coveralls": "^2.13.1",
     "ioredis": "3.x",
     "jsdoc-to-markdown": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "standard": "^10.0.3"
   },
   "dependencies": {
+    "cluster-messages": "^1.1.2",
     "codependency": "^2.0.1",
     "human-interval": "^0.1.6",
     "lodash.clonedeep": "^4.5.0",
@@ -83,7 +84,6 @@
     "precond": "^0.2.3"
   },
   "optionalPeerDependencies": {
-    "cluster-messages": "1.1.2",
     "node-fetch": "1.x",
     "mongodb": "2.x",
     "mongoose": "4.x",


### PR DESCRIPTION
If you this package without `cluster-messages` installed it cases node to throw an error as it requires it to run. Because of this, I've moved `cluster-messages` into the dependencies.

I may be just be fixing the symptom and it could be that `cluster-messages` should be optional.