### PR TITLE
Don't publish npm-shrinkwrap.json.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+npm-shrinkwrap.json


### PR DESCRIPTION
It's [strongly discouraged](https://docs.npmjs.com/files/shrinkwrap.json) for libraries and it looks like it forces dependents packages to install our own devDependencies